### PR TITLE
DiffEqBase tests pass

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FastBroadcast"
 uuid = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 authors = ["Yingbo Ma <mayingbo5@gmail.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 authors = ["Yingbo Ma <mayingbo5@gmail.com> and contributors"]
 version = "0.1.0"
 
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
 [compat]
 julia = "1"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,4 +16,14 @@ using Test
     @test (@.. (x*y) + x + y + x*(3,4,5,6) + y + x * (1,) + y + 3) ≈ (@. (x*y) + x + y + x*(3,4,5,6) + y + x * (1,) + y + 3)
     A = rand(4,4);
     @test (@.. A * y' + x) ≈ (@. A * y' + x)
+    @test (@.. A * transpose(y) + x) ≈ (@. A * transpose(y) + x)
+    Ashim = A[1:1,:];
+    @test (@.. Ashim * y' + x) ≈ (@. Ashim * y' + x) # test fallback
+    Av = view(A,1,:);
+    @test (@.. Av * y' + A) ≈ (@. Av * y' + A)
+    B = similar(A);
+    @.. B = A
+    @test B == A
+    @.. A = 3
+    @test all(==(3), A)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,4 +13,7 @@ using Test
     @test (@.. dest += (x*y) + x + y + x + y + x + y) ≈ 2bcref
     @test (@.. dest -= (x*y) + x + y + x + y + x + y) ≈ bcref
     @test (@.. dest *= (x*y) + x + y + x + y + x + y) ≈ abs2.(bcref)
+    @test (@.. (x*y) + x + y + x*(3,4,5,6) + y + x * (1,) + y + 3) ≈ (@. (x*y) + x + y + x*(3,4,5,6) + y + x * (1,) + y + 3)
+    A = rand(4,4);
+    @test (@.. A * y' + x) ≈ (@. A * y' + x)
 end


### PR DESCRIPTION
This PR makes the following changes:
1. No longer use `ndims` while building the generated function. This causes world age errors when someone adds `ndims` methods.
2. Call `axes` on all the arrays outside of the generated function (to avoid world age problems), and pass these in. The number of axes == the number of dims.
3. Also pass in index styles.
4. Check tuple lengths. If a tuple is of length 1, treat it as a scalar.
5. If any dimensions don't match, call an outlined base broadcast. That'll then either broadcast 1s or throw a dimension mismatch.
6. Check for adjoint/transposes of vectors. We know the first dimension is of size 1, so we can broadcast those ourselves.