### PR TITLE
Remove dots from updates/assignments

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FastBroadcast"
 uuid = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 authors = ["Yingbo Ma <mayingbo5@gmail.com> and Chris Elrod <elrodc@gmail.com>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/FastBroadcast.jl
+++ b/src/FastBroadcast.jl
@@ -222,12 +222,12 @@ end
 
 function broadcast_expr!(ex)
     ex isa Expr || return ex
-    update = findfirst(isequal(ex.head), (:(+=), :(-=), :(*=), :(/=), :(\=), :(^=), :(&=), :(|=), :(⊻=), :(÷=)))
+    update = findfirst(isequal(ex.head), (:(+=), :(-=), :(*=), :(/=), :(\=), :(^=), :(&=), :(|=), :(⊻=), :(÷=), :(.+=), :(.-=), :(.*=), :(./=), :(.\=), :(.^=), :(.&=), :(.|=), :(.⊻=), :(.÷=)))
     if update ≢ nothing
-        lhs = Expr(:call, (:(+), :(-), :(*), :(/), :(\), :(^), :(&), :(|), :(⊻), :(÷))[update], ex.args[1], ex.args[2])
+        lhs = Expr(:call, (:(+), :(-), :(*), :(/), :(\), :(^), :(&), :(|), :(⊻), :(÷))[update % 10], ex.args[1], ex.args[2])
         ex = Expr(:(=), ex.args[1], lhs)
     end
-    if Meta.isexpr(ex, :(=), 2)
+    if Meta.isexpr(ex, :(=), 2) || Meta.isexpr(ex, :(.=), 2)
         return Expr(:call, fast_materialize!, ex.args[1], broadcasted_expr!(ex.args[2]))
     else
         return Expr(:call, fast_materialize, broadcasted_expr!(ex))

--- a/src/FastBroadcast.jl
+++ b/src/FastBroadcast.jl
@@ -222,9 +222,9 @@ end
 
 function broadcast_expr!(ex)
     ex isa Expr || return ex
-    update = findfirst(isequal(ex.head), (:(+=), :(-=), :(*=), :(/=), :(\=), :(^=), :(&=), :(|=), :(⊻=), :(÷=), :(.+=), :(.-=), :(.*=), :(./=), :(.\=), :(.^=), :(.&=), :(.|=), :(.⊻=), :(.÷=)))
+    update = findfirst(Base.Fix1(Base.sym_in, ex.head), ((:(+=),:(.+=)), (:(-=),:(.-=)), (:(*=),:(.*=)), (:(/=),:(./=)), (:(\=),:(.\=)), (:(^=),:(.^=)), (:(&=),:(.&=)), (:(|=),:(.|=)), (:(⊻=),:(.⊻=)), (:(÷=),:(.÷=))))
     if update ≢ nothing
-        lhs = Expr(:call, (:(+), :(-), :(*), :(/), :(\), :(^), :(&), :(|), :(⊻), :(÷))[update % 10], ex.args[1], ex.args[2])
+        lhs = Expr(:call, (:(+), :(-), :(*), :(/), :(\), :(^), :(&), :(|), :(⊻), :(÷))[update], ex.args[1], ex.args[2])
         ex = Expr(:(=), ex.args[1], lhs)
     end
     if Meta.isexpr(ex, :(=), 2) || Meta.isexpr(ex, :(.=), 2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,8 +20,8 @@ if GROUP == "All" || GROUP == "Core"
         dest = similar(bcref);
         @test (@.. dest = (x*y) + x + y + x + y + x + y) == bcref
         @test (@.. (x*y) + x + y + x + y + x + y) == bcref
-        @test (@.. dest += (x*y) + x + y + x + y + x + y) ≈ 2bcref
-        @test (@.. dest -= (x*y) + x + y + x + y + x + y) ≈ bcref
+        @test (@.. dest .+= (x*y) + x + y + x + y + x + y) ≈ 2bcref
+        @test (@.. dest .-= (x*y) + x + y + x + y + x + y) ≈ bcref
         @test (@.. dest *= (x*y) + x + y + x + y + x + y) ≈ abs2.(bcref)
         nt = (x = x,)
         @test (@.. (nt.x*y) + x + y + x*(3,4,5,6) + y + x * (1,) + y + 3) ≈ (@. (x*y) + x + y + x*(3,4,5,6) + y + nt.x * (1,) + y + 3)
@@ -33,7 +33,7 @@ if GROUP == "All" || GROUP == "Core"
         Av = view(A,1,:);
         @test (@.. Av * y' + A) ≈ (@. Av * y' + A)
         B = similar(A);
-        @.. B = A
+        @.. B .= A
         @test B == A
         @.. A = 3
         @test all(==(3), A)


### PR DESCRIPTION
Fixes code such as `@macroexpand @.. a .=  b` and `@macroexpand @.. a .+= b`.