### PR TITLE
More generic broadcast

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FastBroadcast"
 uuid = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 authors = ["Yingbo Ma <mayingbo5@gmail.com> and Chris Elrod <elrodc@gmail.com>"]
-version = "0.2.5"
+version = "0.2.6"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/FastBroadcast.jl
+++ b/src/FastBroadcast.jl
@@ -56,14 +56,14 @@ __view(t::Tuple{T}, r, ::Val{N}) where {T,N} = (_view(first(t), r, Val(N)),)
 __view(t::Tuple{T,Vararg}, r, ::Val{N}) where {T,N} =
     (_view(first(t), r, Val(N)), __view(Base.tail(t), r, Val(N))...)
 function _view(
-    bc::Base.Broadcast.Broadcasted{Base.Broadcast.DefaultArrayStyle{N},Nothing},
+    bc::Base.Broadcast.Broadcasted{<:Base.Broadcast.AbstractArrayStyle{N},Nothing},
     r,
     ::Val{N},
 ) where {N}
-    Base.Broadcast.Broadcasted(bc.f, __view(bc.args, r, Val(N)), Val(N))
+    Base.Broadcast.Broadcasted(bc.f, __view(bc.args, r, Val(N)))
 end
 _view(
-    bc::Base.Broadcast.Broadcasted{<:Base.Broadcast.DefaultArrayStyle},
+    bc::Base.Broadcast.Broadcasted{<:Base.Broadcast.AbstractArrayStyle},
     r,
     ::Val{N},
 ) where {N} = bc


### PR DESCRIPTION
@ranocha 

```julia
julia> using FastBroadcast
[ Info: Precompiling FastBroadcast [7034ab61-46d4-4ed7-9d0f-46aef9175898]

julia> u = [1.0, 2.0]
2-element Vector{Float64}:
 1.0
 2.0

julia> v = [1.0, 2.0]
2-element Vector{Float64}:
 1.0
 2.0

julia> w = zero(u)
2-element Vector{Float64}:
 0.0
 0.0

julia> @.. broadcast=false thread=true w = u + 1.0 * v
2-element Vector{Float64}:
 2.0
 4.0

julia> using StrideArrays

julia> @.. broadcast=false thread=true w = u + 1.0 * v
2-element Vector{Float64}:
 2.0
 4.0
```
from https://github.com/SciML/OrdinaryDiffEq.jl/issues/1989