### PR TITLE
recursively handle right hand side of `=` statement

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,6 +118,10 @@ if GROUP == "All" || GROUP == "Core"
             @test_throws ArgumentError @.. broadcast = false A * [1.0]
         end
         @test FastBroadcast.indices_do_not_alias(typeof(view(fill(0, 10), 1:4)))
+
+        let ex = macroexpand(@__MODULE__, :(@.. broadcast=false @view(J[idxs])=@view(J[idxs]) - inv_alpha))
+            @test Base.Meta.isexpr(ex, :block)
+        end
     end
 
     VERSION >= v"1.6" && PerformanceTestTools.@include("vectorization_tests.jl")


### PR DESCRIPTION
Otherwise we will encounter error like:
```julia
julia> using FastBroadcast

julia> @macroexpand @.. broadcast=false @view(J[idxs])=@view(J[idxs]) - inv_alpha
:($(Expr(:error, "SSAValue objects should not occur in an AST")))
```
This happens because currently FB does not process `=` statement recursively, where the right hand side of the statement can be a complex IR construct.