### PR TITLE
Maybe improve macro-expand time

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         version:
           - '1'
-          - '1.6'
+          - '1.8'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -17,7 +17,7 @@ Polyester = "0.5, 0.6, 0.7"
 Static = "0.3, 0.4, 0.5, 0.6, 0.7, 0.8"
 StaticArrayInterface = "1"
 StrideArraysCore = "0.3, 0.4, 0.5"
-julia = "1.6"
+julia = "1.8"
 
 [extras]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FastBroadcast"
 uuid = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 authors = ["Yingbo Ma <mayingbo5@gmail.com> and Chris Elrod <elrodc@gmail.com>"]
-version = "0.2.8"
+version = "0.3.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/FastBroadcast.jl
+++ b/src/FastBroadcast.jl
@@ -257,15 +257,7 @@ end
   dstaxes::Tuple{Vararg{Any,N}},
 ) where {N,DB}
   last_dstaxes = dstaxes[N]
-  Polyester.batch(
-    _batch_broadcast_fn,
-    (length(last_dstaxes), Threads.nthreads()),
-    dst,
-    last_dstaxes,
-    bc,
-    Val(N),
-    DB(),
-  )
+  Polyester.batch(_batch_broadcast_fn, (length(last_dstaxes), Threads.nthreads()), dst, last_dstaxes, bc, Val(N), DB())
   return dst
 end
 

--- a/src/FastBroadcast.jl
+++ b/src/FastBroadcast.jl
@@ -1,350 +1,389 @@
 module FastBroadcast
 
+using Core: CodeInfo
+using Base: UV_UNKNOWN
 export @..
 
-using StaticArrayInterface: static_axes, known_length
+using StaticArrayInterface: static_axes, static_length
 using ArrayInterface: indices_do_not_alias
 using Base.Broadcast: Broadcasted
 using LinearAlgebra: Adjoint, Transpose
 using Static, Polyester
 using StrideArraysCore: AbstractStrideArray
 
-getstyle(::Type{Broadcasted{S,Axes,F,Args}}) where {S,Axes,F,Args} = S
-getAxes(::Type{Broadcasted{S,Axes,F,Args}}) where {S,Axes,F,Args} = Axes
-getF(::Type{Broadcasted{S,Axes,F,Args}}) where {S,Axes,F,Args} = F
-getArgs(::Type{Broadcasted{S,Axes,F,Args}}) where {S,Axes,F,Args} = collect(Args.parameters)
-getAxes(::Type{T}) where {T<:Tuple} = collect(T.parameters)
 
+struct Fix{N,F,T}
+  f::F
+  x::T
+  @inline Fix{N}(f::F, x::T) where {N,F,T} = new{N,F,T}(f, x)
+end
+@inline (i::Fix{1})(arg) = @inline i.f(i.x, arg)
+@inline (i::Fix{2})(arg) = @inline i.f(arg, i.x)
+
+@inline function to_tup(::Val{M}, i::CartesianIndex{N}) where {M,N}
+  if M < N
+    ntuple(Fix{1}(getindex, Tuple(i)), Val(M))
+  else
+    M == N || error("Array of higher dimension than cartesian index.")
+    Tuple(i)
+  end
+end
+
+
+@inline _fastindex(b::Number, _) = b
+@inline _fastindex(b::Tuple{X}, _) where {X} = only(b)
+@inline _fastindex(b::Base.RefValue, _) = b[]
+@inline _fastindex(b::Tuple{X,Y,Vararg}, i) where {X,Y} = @inbounds b[i]
+@inline _fastindex(b::Broadcasted, i) = b.f(_rmap(Fix{2}(_fastindex, i), b.args)...)
+@inline _fastindex(A::AbstractArray, i::Int) = @inbounds A[i]
+@inline function _fastindex(A::AbstractArray{<:Any,M}, i::CartesianIndex{N}) where {M,N}
+  inds = _rmap(static_axes(A), to_tup(Val(M), i)) do ax, j
+    Bool(_static_one(static_length(ax))) ? 1 : j
+  end
+  @inbounds A[inds...]
+end
+
+
+@inline _slowindex(b::Number, _) = b
+@inline _slowindex(b::Tuple{X}, _) where {X} = only(b)
+@inline _slowindex(b::Base.RefValue, _) = b[]
+@inline _slowindex(b::Tuple{X,Y,Vararg}, i) where {X,Y} = @inbounds b[i]
+@inline _slowindex(b::Broadcasted, i) = b.f(_rmap(Fix{2}(_slowindex, i), b.args)...)
+@inline _slowindex(A::AbstractArray, i::Int) = @inbounds A[i]
+@inline function _slowindex(A::AbstractArray{<:Any,M}, i::CartesianIndex{N}) where {M,N}
+  inds = to_tup(Val(M), i)
+  @inbounds A[_rmap(ifelse, _rmap(isone, size(A)), _rmap(first, axes(A)), inds)...]
+end
+
+@inline _all(_, x::Tuple{}) = True()
+@inline _all(f, x::Tuple{X}) where {X} = f(only(x))
+@inline __all(f::F, ::False, x::Tuple) where {F} = False()
+@inline __all(f::F, ::True, x::Tuple) where {F} = _all(f, x)
+@inline _all(f, x::Tuple{X,Y,Vararg}) where {X,Y} = __all(f, f(first(x)), Base.tail(x))
+@inline _none_one(x) = _all(Fix{2}(Static.ne, Static.One()) ∘ static_length, x)
+
+@inline _any(_, x::Tuple{}) = False()
+@inline _any(f, x::Tuple{X}) where {X} = f(only(x))
+@inline __any(f::F, ::True, x::Tuple) where {F} = True()
+@inline __any(f::F, ::False, x::Tuple) where {F} = _any(f, x)
+@inline _any(f, x::Tuple{X,Y,Vararg}) where {X,Y} = __any(f, f(first(x)), Base.tail(x))
+
+@inline _static_one(::Static.One) = True()
+@inline _static_one(::Any) = False()
+@inline _any_one(x) = _any(_static_one ∘ static_length, x)
+
+@inline _rall(_, x::Tuple{}) = true
+@inline _rall(f, x::Tuple{X}) where {X} = f(only(x))
+@inline _rall(f, x::Tuple{X,Y,Vararg}) where {X,Y} = f(first(x)) && _rall(f, Base.tail(x))
+@inline _rall(x::Tuple) = _rall(identity, x)
+
+@inline _rmap(_, ::Tuple{}) = ()
+@inline _rmap(f, x::Tuple{X}) where {X} = (f(only(x)),)
+@inline _rmap(f, x::Tuple{X,Y,Vararg}) where {X,Y} = (f(first(x)), _rmap(f, Base.tail(x))...)
+
+@inline _rmap(_, ::Tuple{}, ::Tuple{}) = ()
+@inline _rmap(f, a::Tuple{A}, x::Tuple{X}) where {A,X} = (@inline(f(only(a), only(x))),)
+@inline _rmap(f, a::Tuple{A,B,Vararg}, x::Tuple{X,Y,Vararg}) where {A,B,X,Y} = (@inline(f(first(a), first(x))), _rmap(f, Base.tail(a), Base.tail(x))...)
+
+@inline _rmap(_, ::Tuple{}, ::Tuple{}, ::Tuple{}) = ()
+@inline _rmap(f, a::Tuple{A}, m::Tuple{M}, x::Tuple{X}) where {A,M,X} = (@inline(f(only(a), only(m), only(x))),)
+@inline _rmap(f, a::Tuple{A,B,Vararg}, m::Tuple{M,N,Vararg}, x::Tuple{X,Y,Vararg}) where {A,B,M,N,X,Y} = (@inline(f(first(a), first(m), first(x))), _rmap(f, Base.tail(a), Base.tail(m), Base.tail(x))...)
+
+
+
+@inline function _static_match(ax0::Tuple{Vararg{Any,M}}, ax1::Tuple{Vararg{Any,N}}) where {M,N}
+  subax1 = ntuple(Fix{1}(Base.getindex, ax1), Val(M))
+  eqs = _rmap(ax0, subax1) do x0, x1
+    Bool(_static_one(static_length(x0))) || x0 == x1
+  end
+  _rall(eqs)
+end
+@inline function _dynamic_match(ax0::Tuple{Vararg{Any,M}}, ax1::Tuple{Vararg{Any,N}}) where {M,N}
+  subax1 = ntuple(Fix{1}(Base.getindex, ax1), Val(M))
+  eqs = _rmap(ax0, subax1) do x0, x1
+    isone(length(x0)) || x0 == x1
+  end
+  _rall(eqs)
+end
+
+@inline function _static_not_flat(B::AbstractArray, ::Val{N}) where {N}
+  (IndexStyle(typeof(B)) === IndexLinear()) && ndims(B) == N ? _any_one(static_axes(B)) : True()
+end
+@inline function _static_not_flat(bc::Broadcasted, VN::Val)
+  _any(Fix{2}(_static_not_flat, VN), bc.args)
+end
+
+@inline _checkaxes(::Union{Number,Base.RefValue}, _) = true
+@inline function _checkaxes(::Tuple{Vararg{Any,M}}, ax::Tuple{Vararg{Any,N}}) where {M,N}
+  M == 1 || M == length(first(ax))
+end
+@inline function _checkaxes(B::AbstractArray{<:Any,M}, ax::Tuple{Vararg{Any,N}}) where {M,N}
+  _dynamic_match(static_axes(B), ax)
+end
+@inline function _checkaxes(bc::Broadcasted, ax)
+  _rall(_rmap(Fix{2}(_checkaxes, ax), bc.args))
+end
+
+@inline _static_checkaxes(::Union{Number,Base.RefValue}, _) = true, False()
+@inline function _static_checkaxes(::Tuple{Vararg{Any,M}}, ax::Tuple{Vararg{Any,N}}) where {M,N}
+  snf = N == 1 ? False() : True()
+  equal_axes = M == 1 || M == length(first(ax))
+  equal_axes, snf
+end
+@inline function _static_checkaxes(B::AbstractArray{<:Any,M}, ax::Tuple{Vararg{Any,N}}) where {M,N}
+  snf = _static_not_flat(B, Val(N))
+  equal_axes = _static_match(static_axes(B), ax)
+  equal_axes, snf
+end
+@inline function _static_checkaxes(bc::Broadcasted, ax)
+  tups = _rmap(Fix{2}(_static_checkaxes, ax), bc.args)
+  _rall(first, tups), _any(last, tups)
+end
+
+@inline function __fast_materialize!(dst, ::Val{true}, bc::Broadcasted, ::False)
+  @simd ivdep for i = eachindex(dst)
+    @inbounds dst[i] = _fastindex(bc, i)
+  end
+  return dst
+end
+@inline function __fast_materialize!(dst, ::Val{true}, bc::Broadcasted, ::True)
+  @simd ivdep for i = CartesianIndices(dst)
+    @inbounds dst[i] = _fastindex(bc, i)
+  end
+  return dst
+end
+@inline function __fast_materialize!(dst, ::Val{false}, bc::Broadcasted, ::False)
+  for i = eachindex(dst)
+    @inbounds dst[i] = _fastindex(bc, i)
+  end
+  return dst
+end
+@inline function __fast_materialize!(dst, ::Val{false}, bc::Broadcasted, ::True)
+  for i = CartesianIndices(dst)
+    @inbounds dst[i] = _fastindex(bc, i)
+  end
+  return dst
+end
+
+@inline function _fast_materialize!(dst::AbstractArray{<:Any,N}, ::Val{NOALIAS}, ::False, bc::Broadcasted) where {N,NOALIAS}
+  _no_dyn_broadcast, _islinear = _static_checkaxes(bc, static_axes(dst))
+  _no_dyn_broadcast || throw(ArgumentError("Some axes are not equal, or feature a dynamic broadcast!"))
+  __fast_materialize!(dst, Val(NOALIAS), bc, _islinear)
+  return dst
+end
+
+@inline function _fast_materialize!(
+  dst,
+  ::Val{NOALIAS},
+  ::True,
+  bc::Broadcasted,
+) where {NOALIAS}
+  _no_dyn_broadcast, _islinear = _static_checkaxes(bc, static_axes(dst))
+  _no_dyn_broadcast && return __fast_materialize!(dst, Val(NOALIAS), bc, _islinear)
+  _checkaxes(bc, static_axes(dst)) || throw(ArgumentError("Size mismatch."))
+  _slow_materialize!(dst, Val(NOALIAS), bc)
+end
+
+function _slow_materialize!(
+  dst,
+  ::Val{true},
+  bc::Broadcasted,
+)
+  @simd ivdep for i = CartesianIndices(dst)
+    @inbounds dst[i] = _slowindex(bc, i)
+  end
+  return dst
+end
+function _slow_materialize!(
+  dst,
+  ::Val{false},
+  bc::Broadcasted,
+)
+  for i = CartesianIndices(dst)
+    @inbounds dst[i] = _slowindex(bc, i)
+  end
+  return dst
+end
+
+@inline function fast_materialize(::SB, ::DB, bc::Broadcasted{S}) where {S,SB,DB}
+  if use_fast_broadcast(S)
+    fast_materialize!(
+      SB(),
+      DB(),
+      similar(bc, Base.Broadcast.combine_eltypes(bc.f, bc.args)),
+      bc,
+    )
+  else
+    Base.Broadcast.materialize(bc)
+  end
+end
 use_fast_broadcast(_) = false
 use_fast_broadcast(::Type{<:Base.Broadcast.DefaultArrayStyle}) = true
 use_fast_broadcast(::Type{<:Base.Broadcast.DefaultArrayStyle{0}}) = false
 
-@inline function fast_materialize(::SB, ::DB, bc::Broadcasted{S}) where {S,SB,DB}
-    if use_fast_broadcast(S)
-        fast_materialize!(
-            SB(),
-            DB(),
-            similar(bc, Base.Broadcast.combine_eltypes(bc.f, bc.args)),
-            bc,
-        )
-    else
-        Base.Broadcast.materialize(bc)
-    end
-end
 
 @inline function fast_materialize!(::False, ::DB, dst::A, bc::Broadcasted{S}) where {S,DB,A}
-    if use_fast_broadcast(S)
-        _fast_materialize!(
-            dst,
-            Val(indices_do_not_alias(A)),
-            DB(),
-            bc,
-            static_axes(dst),
-            _get_axes(bc),
-            _index_style(bc),
-        )
-    else
-        Base.Broadcast.materialize!(dst, bc)
-    end
+  if use_fast_broadcast(S)
+    _fast_materialize!(
+      dst,
+      Val(indices_do_not_alias(A)),
+      DB(),
+      bc,
+    )
+  else
+    Base.Broadcast.materialize!(dst, bc)
+  end
 end
 
-_view(A::AbstractArray{<:Any,N}, r, ::Val{N}) where {N} =
-    view(A, ntuple(_ -> :, N - 1)..., r)
-_view(A::AbstractArray, r, ::Val) = A
-_view(x, r, ::Val) = x
-__view(t::Tuple{T}, r, ::Val{N}) where {T,N} = (_view(first(t), r, Val(N)),)
-__view(t::Tuple{T,Vararg}, r, ::Val{N}) where {T,N} =
-    (_view(first(t), r, Val(N)), __view(Base.tail(t), r, Val(N))...)
-function _view(
-    bc::Base.Broadcast.Broadcasted{<:Base.Broadcast.AbstractArrayStyle{N},Nothing},
-    r,
-    ::Val{N},
-) where {N}
-    Base.Broadcast.Broadcasted(bc.f, __view(bc.args, r, Val(N)))
+@inline _view(A::AbstractArray{<:Any,N}, r, ::Val{N}) where {N} =
+  view(A, ntuple(_ -> :, N - 1)..., r)
+@inline _view(A::AbstractArray, r, ::Val) = A
+@inline _view(x, r, ::Val) = x
+@inline __view(t::Tuple{T}, r, ::Val{N}) where {T,N} = (_view(first(t), r, Val(N)),)
+@inline __view(t::Tuple{T,Vararg}, r, ::Val{N}) where {T,N} =
+  (_view(first(t), r, Val(N)), __view(Base.tail(t), r, Val(N))...)
+@inline function _view(bc::Base.Broadcast.Broadcasted{<:Base.Broadcast.AbstractArrayStyle{N},Nothing}, r, ::Val{N},) where {N}
+  Base.Broadcast.Broadcasted(bc.f, __view(bc.args, r, Val(N)))
 end
-_view(
-    bc::Base.Broadcast.Broadcasted{<:Base.Broadcast.AbstractArrayStyle},
-    r,
-    ::Val{N},
-) where {N} = bc
-_view(t::Tuple{Vararg{AbstractRange,N}}, r, ::Val{N}) where {N} = (Base.front(t)..., r)
+@inline _view(bc::Base.Broadcast.Broadcasted{<:Base.Broadcast.AbstractArrayStyle}, _, ::Val{N},) where {N} = bc
+@inline _view(t::Tuple{Vararg{AbstractRange,N}}, r, ::Val{N}) where {N} = (Base.front(t)..., r)
 
-function fast_materialize!(::True, ::DB, dst, bc::Broadcasted{S}) where {S,DB}
-    if use_fast_broadcast(S)
-        fast_materialize_threaded!(dst, DB(), bc, static_axes(dst))
-    else
-        Base.Broadcast.materialize!(dst, bc)
-    end
+@inline function fast_materialize!(::True, ::DB, dst, bc::Broadcasted{S}) where {S,DB}
+  if use_fast_broadcast(S)
+    fast_materialize_threaded!(dst, DB(), bc, static_axes(dst))
+  else
+    Base.Broadcast.materialize!(dst, bc)
+  end
 end
 @inline function _batch_broadcast_fn((dest, ldstaxes, bcobj, VN, DoBroadcast), start, stop)
-    r = @inbounds ldstaxes[start:stop]
-    fast_materialize!(False(), DoBroadcast, _view(dest, r, VN), _view(bcobj, r, VN))
-    return nothing
+  r = @inbounds ldstaxes[start:stop]
+  fast_materialize!(False(), DoBroadcast, _view(dest, r, VN), _view(bcobj, r, VN))
+  return nothing
 end
-function fast_materialize_threaded!(
-    dst,
-    ::DB,
-    bc::Broadcasted,
-    dstaxes::Tuple{Vararg{Any,N}},
+@inline function fast_materialize_threaded!(
+  dst,
+  ::DB,
+  bc::Broadcasted,
+  dstaxes::Tuple{Vararg{Any,N}},
 ) where {N,DB}
-    last_dstaxes = dstaxes[N]
-    Polyester.batch(
-        _batch_broadcast_fn,
-        (length(last_dstaxes), Threads.nthreads()),
-        dst,
-        last_dstaxes,
-        bc,
-        Val(N),
-        DB(),
-    )
-    return dst
+  last_dstaxes = dstaxes[N]
+  Polyester.batch(
+    _batch_broadcast_fn,
+    (length(last_dstaxes), Threads.nthreads()),
+    dst,
+    last_dstaxes,
+    bc,
+    Val(N),
+    DB(),
+  )
+  return dst
 end
 
 
-@inline _get_axes(x) = static_axes(x)
-@inline _get_axes(bc::Broadcasted) = map(_get_axes, bc.args)
-@inline __index_style(_) = Val{false}()
-@inline __index_style(::IndexLinear) = Val{true}()
-
-# Two arg `_index_style` checks, either stopping with `Val{false}()`, or continues
-@inline _index_style(_, __) = IndexCartesian()
-@inline _index_style(::IndexLinear, x) = _index_style(x)
-@inline _index_style(::IndexLinear, x::Tuple{}) = IndexLinear()
-@inline _index_style(::IndexLinear, x::Tuple{T}) where {T} = _index_style(first(x))
-@inline _index_style(::IndexLinear, x::Tuple{T,S,Vararg}) where {T,S} =
-    _index_style(_index_style(first(x)), Base.tail(x))
-
-@inline _index_style(x) = IndexStyle(typeof(x)) # require `IndexStyle` to be defined
-@inline _index_style(x::Tuple) = IndexLinear()
-@inline _index_style(x::Number) = IndexLinear()
-@inline _index_style(x::Ref) = IndexLinear()
-@inline _index_style(x::AbstractArray) = IndexStyle(x)
-
-@inline _index_style(bc::Broadcasted) =
-    _index_style(_index_style(first(bc.args)), Base.tail(bc.args))
-
-@generated function broadcastgetindex(A, i::Vararg{Any,N}) where {N}
-    quote
-        $(Expr(:meta, :inline))
-        Base.Cartesian.@nref $N A n ->
-            ifelse(size(A, n) == 1, (firstindex(A, n) % Int)::Int, (i[n] % Int)::Int)
-    end
-end
-
-fast_materialize!(_, __, dest, x::Number) = fill!(dest, x)
-fast_materialize!(_, __, dest, x::AbstractArray) =
-    length(x) == 1 ? fill!(dest, x) : copyto!(dest, x)
-
-mutable struct BroadcastCharacteristics
-    loopheader::Expr
-    arrays::Vector{Symbol}
-    maybelinear::Bool
-end
-BroadcastCharacteristics() = BroadcastCharacteristics(Expr(:block), Symbol[], true)
-
-_tuplelen(::Type{T}) where {N,T<:Tuple{Vararg{Any,N}}} = N
-
-function walk_bc!(
-    bcc::BroadcastCharacteristics,
-    loopbody_lin::Expr,
-    loopbody_car::Expr,
-    loopbody_slow::Expr,
-    ii::Vector{Symbol},
-    @nospecialize(bc::Type{<:Broadcasted}),
-    bcsym::Symbol,
-    @nospecialize(ax::Type{<:Tuple}),
-    axsym::Symbol,
-)
-    f = gensym(:f)
-    push!(bcc.loopheader.args, :($f = $bcsym.f))
-    new_loopbody_lin = Expr(:call, f)
-    new_loopbody_car = Expr(:call, f)
-    new_loopbody_slow = Expr(:call, f)
-    args = getArgs(bc)
-    axs = getAxes(ax)
-    push!(loopbody_lin.args, new_loopbody_lin)
-    push!(loopbody_car.args, new_loopbody_car)
-    push!(loopbody_slow.args, new_loopbody_slow)
-    for (i, arg) in enumerate(args)
-        if arg <: Broadcasted
-            new_bcsym = gensym(:bcsym)
-            new_axsym = gensym(:axsym)
-            push!(bcc.loopheader.args, :($new_bcsym = $bcsym.args[$i]))
-            push!(bcc.loopheader.args, :($new_axsym = $axsym[$i]))
-            walk_bc!(
-                bcc,
-                new_loopbody_lin,
-                new_loopbody_car,
-                new_loopbody_slow,
-                ii,
-                arg,
-                new_bcsym,
-                axs[i],
-                new_axsym,
-            )
-        else
-            new_arg = gensym(:x)
-            push!(bcc.loopheader.args, :($new_arg = $bcsym.args[$i]))
-            nd::Int = length(ii)
-            if arg <: Tuple
-                tuple_length = _tuplelen(arg)
-                if tuple_length == 1
-                    scalar = gensym(:scalar)
-                    push!(bcc.loopheader.args, :($scalar = $new_arg[1]))
-                    push!(new_loopbody_lin.args, scalar)
-                    push!(new_loopbody_car.args, scalar)
-                    push!(new_loopbody_slow.args, scalar)
-                else
-                    bcc.maybelinear &= nd == 1
-                    push!(
-                        bcc.loopheader.args,
-                        :(isfast &= Base.OneTo($tuple_length) == dstaxis_1),
-                    )
-                    push!(new_loopbody_lin.args, :($new_arg[i]))
-                    push!(new_loopbody_car.args, :($new_arg[i1]))
-                    push!(new_loopbody_slow.args, :($new_arg[i1]))
-                end
-            else
-                new_nd::Int = _tuplelen(axs[i]) # ndims on `arg` won't work because of possible world age errors.
-                if new_nd == 0
-                    scalar = gensym(:scalar)
-                    push!(bcc.loopheader.args, :($scalar = $new_arg[]))
-                    push!(new_loopbody_lin.args, scalar)
-                    push!(new_loopbody_car.args, scalar)
-                    push!(new_loopbody_slow.args, scalar)
-                else
-                    push!(bcc.arrays, new_arg)
-                    bcc.maybelinear &= (nd == new_nd)
-                    new_arg_axes = Symbol(new_arg, "#axes#")
-                    push!(bcc.loopheader.args, :($new_arg_axes = $axsym[$i]))
-                    push!(
-                        bcc.loopheader.args,
-                        :((Base.Cartesian.@ntuple $new_nd $new_arg_axes) = $new_arg_axes),
-                    )
-                    newarg_cartesian_index = Expr(:ref, new_arg)
-                    newarg_slow_index = Expr(:call, broadcastgetindex, new_arg)
-                    for n ∈ 1:new_nd
-                        kl = known_length(axs[i].parameters[n])
-                        if kl === 1
-                            bcc.maybelinear = false
-                            push!(newarg_cartesian_index.args, 1)
-                            push!(newarg_slow_index.args, 1)
-                        else
-                            push!(
-                                bcc.loopheader.args,
-                                :(
-                                    isfast &=
-                                        $(Symbol(new_arg_axes, '_', n)) ==
-                                        $(Symbol(:dstaxis_, n))
-                                ),
-                            )
-                            push!(newarg_cartesian_index.args, ii[n])
-                            push!(newarg_slow_index.args, ii[n])
-                        end
-                    end
-                    push!(new_loopbody_lin.args, :($new_arg[i]))
-                    push!(new_loopbody_car.args, newarg_cartesian_index)
-                    push!(
-                        new_loopbody_slow.args,
-                        :(broadcastgetindex($new_arg, $(ii[1:new_nd]...))),
-                    )
-                end
-            end
-        end
-    end
-    return nothing
-end
 
 function pushsymname!(ex::Expr, base::Symbol, @nospecialize(arg))
-    if arg isa Core.SSAValue
-        push!(ex.args, Symbol(base, '_', arg.id))
-    elseif arg isa Core.SlotNumber
-        push!(ex.args, Symbol(base, 's', arg.id))
-    else
-        push!(ex.args, arg)
-    end
+  if arg isa Core.SSAValue
+    push!(ex.args, Symbol(base, '_', arg.id))
+  elseif arg isa Core.SlotNumber
+    push!(ex.args, Symbol(base, 's', arg.id))
+  else
+    push!(ex.args, arg)
+  end
 end
 function _goto(base::Symbol, i::Int, sym::Symbol)
-    Expr(
-        :macrocall,
-        sym,
-        LineNumberNode(@__LINE__, Symbol(@__FILE__)),
-        Symbol(base, "#label#", i),
-    )
+  Expr(
+    :macrocall,
+    sym,
+    LineNumberNode(@__LINE__, Symbol(@__FILE__)),
+    Symbol(base, "#label#", i),
+  )
 end
 goto(base::Symbol, i::Int) = _goto(base, i, Symbol("@goto"))
 label(base::Symbol, i::Int) = _goto(base, i, Symbol("@label"))
 
-function gotoifnot_stmt(base::Symbol, @nospecialize(cond), dest::Int)
-    ex = Expr(:||)
-    pushsymname!(ex, base, cond)
-    push!(ex.args, goto(base, dest))
-    return ex
+function gotoifnot_stmt(base::Symbol, cond, dest::Int)
+  ex = Expr(:||)
+  pushsymname!(ex, base, cond)
+  push!(ex.args, goto(base, dest))
+  return ex
+end
+function _push_static_bool!(ex::Expr, b)
+  if !(b isa Bool)
+    push!(ex.args, b)
+  elseif b
+    push!(ex.args, True())
+  else
+    push!(ex.args, False())
+  end
 end
 
 function broadcast_stmt!(gotos::Vector{Int}, base::Symbol, i::Int,
-                         threadarg, broadcastarg, @nospecialize code)
-    if Meta.isexpr(code, :call)
-        ex = Expr(:call)
-        f = code.args[1]
-        if f === GlobalRef(Base, :materialize)
-            push!(ex.args, fast_materialize, threadarg, broadcastarg)
-        elseif f === GlobalRef(Base, :materialize!)
-            push!(ex.args, fast_materialize!, threadarg, broadcastarg)
-        elseif f === GlobalRef(Base, :getindex)
-            push!(ex.args, Base.Broadcast.dotview)
-        else
-            pushsymname!(ex, base, f)
-        end
-        for arg ∈ @view(code.args[2:end])
-            pushsymname!(ex, base, arg)
-        end
-        return Expr(:(=), Symbol(base, '_', i), ex)
-    elseif Meta.isexpr(code, :(=))
-        ex = Expr(:(=), Symbol(base, 's', code.args[1].id))
-        rhs = broadcast_stmt!(gotos, base, i, threadarg, broadcastarg, code.args[2])
-        pushsymname!(ex, base, rhs)
-        return ex
-    elseif VERSION ≥ v"1.6" && code isa Core.GotoIfNot
-        push!(gotos, code.dest)
-        return gotoifnot_stmt(base, code.cond, code.dest)
-    elseif VERSION < v"1.6" && Meta.isexpr(code, :gotoifnot)
-        cond, dest = code.args
-        push!(gotos, dest)
-        return gotoifnot_stmt(base, cond, dest)
-    elseif code isa Core.GotoNode
-        push!(gotos, code.label)
-        ex = goto(base, code.label)
-        return ex
-    elseif !(VERSION ≥ v"1.6" ? isa(code, Core.ReturnNode) : Meta.isexpr(code, :return))
-        ex = Expr(:(=), Symbol(base, '_', i))
-        pushsymname!(ex, base, code)
-        return ex
+  threadarg, broadcastarg, @nospecialize(code))
+  if Meta.isexpr(code, :call)
+    ex = Expr(:call)
+    f = code.args[1]
+    if f === GlobalRef(Base, :materialize)
+      push!(ex.args, fast_materialize)
+      _push_static_bool!(ex, threadarg)
+      _push_static_bool!(ex, broadcastarg)
+    elseif f === GlobalRef(Base, :materialize!)
+      push!(ex.args, fast_materialize!)
+      _push_static_bool!(ex, threadarg)
+      _push_static_bool!(ex, broadcastarg)
+    elseif f === GlobalRef(Base, :getindex)
+      push!(ex.args, Base.Broadcast.dotview)
+    else
+      pushsymname!(ex, base, f)
     end
-    return nothing
+    for arg ∈ @view(code.args[2:end])
+      pushsymname!(ex, base, arg)
+    end
+    return Expr(:(=), Symbol(base, '_', i), ex)
+  elseif Meta.isexpr(code, :(=))
+    ex = Expr(:(=), Symbol(base, 's', code.args[1].id))
+    rhs = broadcast_stmt!(gotos, base, i, threadarg, broadcastarg, code.args[2])
+    pushsymname!(ex, base, rhs)
+    return ex
+  elseif VERSION ≥ v"1.6" && code isa Core.GotoIfNot
+    push!(gotos, code.dest)
+    return gotoifnot_stmt(base, code.cond, code.dest)
+  elseif VERSION < v"1.6" && Meta.isexpr(code, :gotoifnot)
+    cond, dest = code.args
+    push!(gotos, dest)
+    return gotoifnot_stmt(base, cond, dest)
+  elseif code isa Core.GotoNode
+    push!(gotos, code.label)
+    ex = goto(base, code.label)
+    return ex
+  elseif !(VERSION ≥ v"1.6" ? isa(code, Core.ReturnNode) : Meta.isexpr(code, :return))
+    ex = Expr(:(=), Symbol(base, '_', i))
+    pushsymname!(ex, base, code)
+    return ex
+  end
+  return nothing
 end
 
 function broadcast_codeinfo(ci, threadarg, broadcastarg)
-    q = Expr(:block)
-    base = gensym(:fastbroadcast)
-    gotos = Int[]
-    for (i, code) ∈ enumerate(ci.code)
-        k = findfirst(==(i), gotos)
-        if k ≢ nothing
-            push!(q.args, label(base, i))
-        end
-        ex = broadcast_stmt!(gotos, base, i, threadarg, broadcastarg, code)
-        if ex !== nothing
-            push!(q.args, ex)
-        end
+  q = Expr(:block)
+  base = gensym(:fastbroadcast)
+  gotos = Int[]
+  for (i, code) ∈ enumerate(ci.code)
+    k = findfirst(==(i), gotos)
+    if k ≢ nothing
+      push!(q.args, label(base, i))
     end
-    q
+    ex = broadcast_stmt!(gotos, base, i, threadarg, broadcastarg, code)
+    if ex !== nothing
+      push!(q.args, ex)
+    end
+  end
+  q
 end
 
-function fb_macro(ex, mod, threadarg, broadcastarg)
-    lowered = Meta.lower(mod, Base.Broadcast.__dot__(ex))
-    lowered isa Expr || return esc(lowered)
-    esc(broadcast_codeinfo(lowered.args[1], threadarg, broadcastarg))
+function fb_macro(ex::Expr, mod::Module, threadarg, broadcastarg)
+  lowered = Meta.lower(mod, Base.Broadcast.__dot__(ex))
+  lowered isa Expr || return esc(lowered)
+  esc(broadcast_codeinfo(lowered.args[1], threadarg, broadcastarg))
 end
 
 """
@@ -362,128 +401,45 @@ It additionally provides two optional keyword arguments:
     base broadcasting only supports `broadcast=true`.
 """
 macro (..)(ex)
-    fb_macro(ex, __module__, False(), False())
+  ex isa Expr || return esc(ex)
+  fb_macro(ex, __module__, false, false)
 end
 
 function __process_kwarg(kwarg)
-    threadarg = kwarg.args[2]
-    threadarg isa Bool ? (threadarg ? True() : False()) : threadarg
+  kwarg.args[2]
 end
 function _validate_kwarg(kwarg)
-    @assert Meta.isexpr(kwarg, :(=), 2)
-    argname = kwarg.args[1]
-    @assert (argname === :thread) || (argname === :broadcast)
-    argname === :thread
+  @assert Meta.isexpr(kwarg, :(=), 2)
+  argname = kwarg.args[1]
+  @assert (argname === :thread) || (argname === :broadcast)
+  argname === :thread
 end
-function _process_kwarg(kwarg, threadarg = False(), broadcastarg = False())
-    if _validate_kwarg(kwarg)
-        return __process_kwarg(kwarg), broadcastarg
-    else
-        return threadarg, __process_kwarg(kwarg)
-    end
+function _process_kwarg(kwarg, threadarg=false, broadcastarg=false)
+  if _validate_kwarg(kwarg)
+    return __process_kwarg(kwarg), broadcastarg
+  else
+    return threadarg, __process_kwarg(kwarg)
+  end
 end
 
 macro (..)(kwarg, ex)
-    threadarg, broadcastarg = _process_kwarg(kwarg)
-    fb_macro(ex, __module__, threadarg, broadcastarg)
+  threadarg, broadcastarg = _process_kwarg(kwarg)
+  fb_macro(ex, __module__, threadarg, broadcastarg)
 end
 macro (..)(kwarg0, kwarg1, ex)
-    threadarg, broadcastarg = _process_kwarg(kwarg0)
-    threadarg, broadcastarg = _process_kwarg(kwarg1, threadarg, broadcastarg)
-    fb_macro(ex, __module__, threadarg, broadcastarg)
+  threadarg, broadcastarg = _process_kwarg(kwarg0)
+  threadarg, broadcastarg = _process_kwarg(kwarg1, threadarg, broadcastarg)
+  fb_macro(ex, __module__, threadarg, broadcastarg)
 end
 
-const DEBUG = Ref(false)
-@generated function _fast_materialize!(
-    dst,
-    ::Val{NOALIAS},
-    ::DB,
-    bc::Broadcasted,
-    dstaxes::Tuple{Vararg{Any,N}},
-    ax,
-    indexstyle,
-) where {N,DB,NOALIAS}
-    loopbody_lin = :($setindex!(dst))
-    loopbody_car = :($setindex!(dst))
-    loopbody_slow = :($setindex!(dst))
-    bcc = BroadcastCharacteristics()
-    ii = map(Base.Fix1(Symbol, :i_), 1:N)
-    walk_bc!(bcc, loopbody_lin, loopbody_car, loopbody_slow, ii, bc, :bc, ax, :ax)
-    push!(loopbody_lin.args, :i)
-    append!(loopbody_car.args, ii)
-    append!(loopbody_slow.args, ii)
-    loop_quote = if N > 1 && !(bcc.maybelinear && (indexstyle === IndexLinear))
-        loop = if NOALIAS
-            quote
-                @simd ivdep for i_1 in $static_axes(dst, 1)
-                    $loopbody_car
-                end
-            end
-        else
-            quote
-                @simd for i_1 in $static_axes(dst, 1)
-                    $loopbody_car
-                end
-            end
-        end
-        for n = N:-1:2
-            loop = quote
-                for $(ii[n]) in $static_axes(dst, $n)
-                    $loop
-                end
-            end
-        end
-        loop
-    elseif NOALIAS
-        quote
-            @simd ivdep for i in $eachindex(dst)
-                $loopbody_lin
-            end
-        end
-    else
-        quote
-            @simd for i in $eachindex(dst)
-                $loopbody_lin
-            end
-        end
+let # we could check `hasfield(Method, :recursion_relation)`, but I'd rather see an error if things change
+  dont_limit = Returns(true)
+  for f in (_fastindex, _slowindex, _static_not_flat, _checkaxes, _static_checkaxes, _fast_materialize!, __any, _any, __all, _all, _rall, _rmap, __view, _view)
+    for m in methods(f)
+      m.recursion_relation = dont_limit
     end
-    q = quote
-        $(Expr(:meta, :inline))
-        isfast = true
-        (Base.Cartesian.@ntuple $N dstaxis) = dstaxes
-        $(bcc.loopheader)
-    end
-    if DB === False
-        if DEBUG[]
-            push!(
-                q.args,
-                quote
-                    if isfast
-                        @inbounds $loop_quote
-                    else
-                        throw(
-                            ArgumentError(
-                                "Could not avoid broadcasting, because an axis had runtime size=1. Axes were: $(ax).",
-                            ),
-                        )
-                    end
-                end,
-            )
-        else
-            push!(q.args, :(@inbounds $loop_quote))
-        end
-    else
-        push!(q.args, quote
-            if isfast
-                @inbounds $loop_quote
-            else
-                Base.Cartesian.@nloops $N i dst begin
-                    $loopbody_slow
-                end
-            end
-        end)
-    end
-    push!(q.args, :dst)
-    return q
+  end
 end
+
+
 end

--- a/src/FastBroadcast.jl
+++ b/src/FastBroadcast.jl
@@ -165,19 +165,14 @@ end
   return dst
 end
 
-@inline function _fast_materialize!(dst::AbstractArray{<:Any,N}, ::Val{NOALIAS}, ::False, bc::Broadcasted) where {N,NOALIAS}
+@inline function _fast_materialize!(dst, ::Val{NOALIAS}, ::False, bc::Broadcasted) where {NOALIAS}
   _no_dyn_broadcast, _islinear = _static_checkaxes(bc, static_axes(dst))
   @boundscheck _no_dyn_broadcast || throw(ArgumentError("Some axes are not equal, or feature a dynamic broadcast!"))
   __fast_materialize!(dst, Val(NOALIAS), bc, _islinear)
   return dst
 end
 
-@inline function _fast_materialize!(
-  dst,
-  ::Val{NOALIAS},
-  ::True,
-  bc::Broadcasted,
-) where {NOALIAS}
+@inline function _fast_materialize!(dst, ::Val{NOALIAS}, ::True, bc::Broadcasted) where {NOALIAS}
   _no_dyn_broadcast, _islinear = _static_checkaxes(bc, static_axes(dst))
   _no_dyn_broadcast && return __fast_materialize!(dst, Val(NOALIAS), bc, _islinear)
   @boundscheck _checkaxes(bc, static_axes(dst)) || throw(ArgumentError("Size mismatch."))

--- a/src/FastBroadcast.jl
+++ b/src/FastBroadcast.jl
@@ -56,16 +56,16 @@ end
   @inbounds A[_rmap(ifelse, _rmap(isone, size(A)), _rmap(first, axs), to_tup(Val(length(axs)), i))...]
 end
 
-@inline _all(_, x::Tuple{}) = True()
+@inline _all(@nospecialize(_), x::Tuple{}) = True()
 @inline _all(f, x::Tuple{X}) where {X} = f(only(x))
-@inline __all(f::F, ::False, x::Tuple) where {F} = False()
+@inline __all(@nospecialize(_), ::False, x::Tuple) = False()
 @inline __all(f::F, ::True, x::Tuple) where {F} = _all(f, x)
 @inline _all(f, x::Tuple{X,Y,Vararg}) where {X,Y} = __all(f, f(first(x)), Base.tail(x))
 @inline _none_one(x) = _all(Fix{2}(Static.ne, Static.One()) ∘ static_length, x)
 
-@inline _any(_, x::Tuple{}) = False()
+@inline _any(@nospecialize(_), x::Tuple{}) = False()
 @inline _any(f, x::Tuple{X}) where {X} = f(only(x))
-@inline __any(f::F, ::True, x::Tuple) where {F} = True()
+@inline __any(@nospecialize(_), ::True, x::Tuple) = True()
 @inline __any(f::F, ::False, x::Tuple) where {F} = _any(f, x)
 @inline _any(f, x::Tuple{X,Y,Vararg}) where {X,Y} = __any(f, f(first(x)), Base.tail(x))
 
@@ -73,20 +73,20 @@ end
 @inline _static_one(::Any) = False()
 @inline _any_one(x) = _any(_static_one ∘ static_length, x)
 
-@inline _rall(_, x::Tuple{}) = true
+@inline _rall(@nospecialize(_), x::Tuple{}) = true
 @inline _rall(f, x::Tuple{X}) where {X} = f(only(x))
 @inline _rall(f, x::Tuple{X,Y,Vararg}) where {X,Y} = f(first(x)) && _rall(f, Base.tail(x))
 @inline _rall(x::Tuple) = _rall(identity, x)
 
-@inline _rmap(_, ::Tuple{}) = ()
+@inline _rmap(@nospecialize(_), ::Tuple{}) = ()
 @inline _rmap(f, x::Tuple{X}) where {X} = (f(only(x)),)
 @inline _rmap(f, x::Tuple{X,Y,Vararg}) where {X,Y} = (f(first(x)), _rmap(f, Base.tail(x))...)
 
-@inline _rmap(_, ::Tuple{}, ::Tuple{}) = ()
+@inline _rmap(@nospecialize(_), ::Tuple{}, ::Tuple{}) = ()
 @inline _rmap(f, a::Tuple{A}, x::Tuple{X}) where {A,X} = (@inline(f(only(a), only(x))),)
 @inline _rmap(f, a::Tuple{A,B,Vararg}, x::Tuple{X,Y,Vararg}) where {A,B,X,Y} = (@inline(f(first(a), first(x))), _rmap(f, Base.tail(a), Base.tail(x))...)
 
-@inline _rmap(_, ::Tuple{}, ::Tuple{}, ::Tuple{}) = ()
+@inline _rmap(@nospecialize(_), ::Tuple{}, ::Tuple{}, ::Tuple{}) = ()
 @inline _rmap(f, a::Tuple{A}, m::Tuple{M}, x::Tuple{X}) where {A,M,X} = (@inline(f(only(a), only(m), only(x))),)
 @inline _rmap(f, a::Tuple{A,B,Vararg}, m::Tuple{M,N,Vararg}, x::Tuple{X,Y,Vararg}) where {A,B,M,N,X,Y} = (@inline(f(first(a), first(m), first(x))), _rmap(f, Base.tail(a), Base.tail(m), Base.tail(x))...)
 

--- a/src/FastBroadcast.jl
+++ b/src/FastBroadcast.jl
@@ -1,7 +1,7 @@
 module FastBroadcast
 
 using Core: CodeInfo
-using Base: UV_UNKNOWN, @propagate_inbounds
+using Base: UV_UNKNOWN, @propagate_inbounds, threadcall_restrictor
 export @..
 
 using StaticArrayInterface: static_axes, static_length
@@ -11,63 +11,61 @@ using LinearAlgebra: Adjoint, Transpose
 using Static, Polyester
 using StrideArraysCore: AbstractStrideArray
 
-
-struct Fix{N,F,T}
-  f::F
-  x::T
-  @inline Fix{N}(f::F, x::T) where {N,F,T} = new{N,F,T}(f, x)
+struct Fix{N, F, T}
+    f::F
+    x::T
+    @inline Fix{N}(f::F, x::T) where {N, F, T} = new{N, F, T}(f, x)
 end
 @inline (i::Fix{1})(arg) = @inline i.f(i.x, arg)
 @inline (i::Fix{2})(arg) = @inline i.f(arg, i.x)
 
-@inline function to_tup(::Val{M}, i::CartesianIndex{N}) where {M,N}
-  if M < N
-    ntuple(Fix{1}(getindex, Tuple(i)), Val(M))
-  else
-    M == N || error("Array of higher dimension than cartesian index.")
-    Tuple(i)
-  end
+@inline function to_tup(::Val{M}, i::CartesianIndex{N}) where {M, N}
+    if M < N
+        ntuple(Fix{1}(getindex, Tuple(i)), Val(M))
+    else
+        M == N || error("Array of higher dimension than cartesian index.")
+        Tuple(i)
+    end
 end
-
 
 @inline _fastindex(b::Number, _) = b
 @inline _fastindex(b::Tuple{X}, _) where {X} = only(b)
 @inline _fastindex(b::Base.RefValue, _) = b[]
-@inline _fastindex(b::Tuple{X,Y,Vararg}, i) where {X,Y} = @inbounds b[i]
+@inline _fastindex(b::Tuple{X, Y, Vararg}, i) where {X, Y} = @inbounds b[i]
 @inline _fastindex(b::Broadcasted, i) = b.f(_rmap(Fix{2}(_fastindex, i), b.args)...)
 @inline function _fastindex(A, i)
-  i isa Int && return @inbounds A[i]
-  axs = static_axes(A)
-  inds = _rmap(axs, to_tup(Val(length(axs)), i)) do ax, j
-    Bool(_static_one(static_length(ax))) ? 1 : j
-  end
-  @inbounds A[inds...]
+    i isa Int && return @inbounds A[i]
+    axs = static_axes(A)
+    inds = _rmap(axs, to_tup(Val(length(axs)), i)) do ax, j
+        Bool(_static_one(static_length(ax))) ? 1 : j
+    end
+    @inbounds A[inds...]
 end
-
 
 @inline _slowindex(b::Number, _) = b
 @inline _slowindex(b::Tuple{X}, _) where {X} = only(b)
 @inline _slowindex(b::Base.RefValue, _) = b[]
-@inline _slowindex(b::Tuple{X,Y,Vararg}, i) where {X,Y} = @inbounds b[i]
+@inline _slowindex(b::Tuple{X, Y, Vararg}, i) where {X, Y} = @inbounds b[i]
 @inline _slowindex(b::Broadcasted, i) = b.f(_rmap(Fix{2}(_slowindex, i), b.args)...)
 @inline function _slowindex(A, i)
-  i isa Int && return @inbounds A[i]
-  axs = static_axes(A)
-  @inbounds A[_rmap(ifelse, _rmap(isone, size(A)), _rmap(first, axs), to_tup(Val(length(axs)), i))...]
+    i isa Int && return @inbounds A[i]
+    axs = static_axes(A)
+    @inbounds A[_rmap(
+        ifelse, _rmap(isone, size(A)), _rmap(first, axs), to_tup(Val(length(axs)), i))...]
 end
 
 @inline _all(@nospecialize(_), x::Tuple{}) = True()
 @inline _all(f, x::Tuple{X}) where {X} = f(only(x))
 @inline __all(@nospecialize(_), ::False, x::Tuple) = False()
 @inline __all(f::F, ::True, x::Tuple) where {F} = _all(f, x)
-@inline _all(f, x::Tuple{X,Y,Vararg}) where {X,Y} = __all(f, f(first(x)), Base.tail(x))
+@inline _all(f, x::Tuple{X, Y, Vararg}) where {X, Y} = __all(f, f(first(x)), Base.tail(x))
 @inline _none_one(x) = _all(Fix{2}(Static.ne, Static.One()) ∘ static_length, x)
 
 @inline _any(@nospecialize(_), x::Tuple{}) = False()
 @inline _any(f, x::Tuple{X}) where {X} = f(only(x))
 @inline __any(@nospecialize(_), ::True, x::Tuple) = True()
 @inline __any(f::F, ::False, x::Tuple) where {F} = _any(f, x)
-@inline _any(f, x::Tuple{X,Y,Vararg}) where {X,Y} = __any(f, f(first(x)), Base.tail(x))
+@inline _any(f, x::Tuple{X, Y, Vararg}) where {X, Y} = __any(f, f(first(x)), Base.tail(x))
 
 @inline _static_one(::Static.One) = True()
 @inline _static_one(::Any) = False()
@@ -75,283 +73,287 @@ end
 
 @inline _rall(@nospecialize(_), x::Tuple{}) = true
 @inline _rall(f, x::Tuple{X}) where {X} = f(only(x))
-@inline _rall(f, x::Tuple{X,Y,Vararg}) where {X,Y} = f(first(x)) && _rall(f, Base.tail(x))
+@inline _rall(f, x::Tuple{X, Y, Vararg}) where {X, Y} = f(first(x)) &&
+                                                        _rall(f, Base.tail(x))
 @inline _rall(x::Tuple) = _rall(identity, x)
 
 @inline _rmap(@nospecialize(_), ::Tuple{}) = ()
 @inline _rmap(f, x::Tuple{X}) where {X} = (f(only(x)),)
-@inline _rmap(f, x::Tuple{X,Y,Vararg}) where {X,Y} = (f(first(x)), _rmap(f, Base.tail(x))...)
+@inline _rmap(f, x::Tuple{X, Y, Vararg}) where {X, Y} = (
+    f(first(x)), _rmap(f, Base.tail(x))...)
 
 @inline _rmap(@nospecialize(_), ::Tuple{}, ::Tuple{}) = ()
-@inline _rmap(f, a::Tuple{A}, x::Tuple{X}) where {A,X} = (@inline(f(only(a), only(x))),)
-@inline _rmap(f, a::Tuple{A,B,Vararg}, x::Tuple{X,Y,Vararg}) where {A,B,X,Y} = (@inline(f(first(a), first(x))), _rmap(f, Base.tail(a), Base.tail(x))...)
+@inline _rmap(f, a::Tuple{A}, x::Tuple{X}) where {A, X} = (@inline(f(only(a), only(x))),)
+@inline _rmap(f, a::Tuple{A, B, Vararg}, x::Tuple{X, Y, Vararg}) where {A, B, X, Y} = (
+    @inline(f(first(a), first(x))), _rmap(f, Base.tail(a), Base.tail(x))...)
 
 @inline _rmap(@nospecialize(_), ::Tuple{}, ::Tuple{}, ::Tuple{}) = ()
-@inline _rmap(f, a::Tuple{A}, m::Tuple{M}, x::Tuple{X}) where {A,M,X} = (@inline(f(only(a), only(m), only(x))),)
-@inline _rmap(f, a::Tuple{A,B,Vararg}, m::Tuple{M,N,Vararg}, x::Tuple{X,Y,Vararg}) where {A,B,M,N,X,Y} = (@inline(f(first(a), first(m), first(x))), _rmap(f, Base.tail(a), Base.tail(m), Base.tail(x))...)
+@inline _rmap(f, a::Tuple{A}, m::Tuple{M}, x::Tuple{X}) where {A, M, X} = (@inline(f(
+    only(a), only(m), only(x))),)
+@inline _rmap(f, a::Tuple{A, B, Vararg}, m::Tuple{M, N, Vararg}, x::Tuple{X, Y, Vararg}) where {A, B, M, N, X, Y} = (
+    @inline(f(first(a), first(m), first(x))),
+    _rmap(f, Base.tail(a), Base.tail(m), Base.tail(x))...)
 
-
-
-@inline function _static_match(ax0::Tuple{Vararg{Any,M}}, ax1::Tuple{Vararg{Any,N}}) where {M,N}
-  subax1 = ntuple(Fix{1}(Base.getindex, ax1), Val(M))
-  eqs = _rmap(ax0, subax1) do x0, x1
-    Bool(_static_one(static_length(x0))) || x0 == x1
-  end
-  _rall(eqs)
+@inline function _static_match(
+        ax0::Tuple{Vararg{Any, M}}, ax1::Tuple{Vararg{Any, N}}) where {M, N}
+    subax1 = ntuple(Fix{1}(Base.getindex, ax1), Val(M))
+    eqs = _rmap(ax0, subax1) do x0, x1
+        Bool(_static_one(static_length(x0))) || x0 == x1
+    end
+    _rall(eqs)
 end
-@inline function _dynamic_match(ax0::Tuple{Vararg{Any,M}}, ax1::Tuple{Vararg{Any,N}}) where {M,N}
-  subax1 = ntuple(Fix{1}(Base.getindex, ax1), Val(M))
-  eqs = _rmap(ax0, subax1) do x0, x1
-    isone(length(x0)) || x0 == x1
-  end
-  _rall(eqs)
+@inline function _dynamic_match(
+        ax0::Tuple{Vararg{Any, M}}, ax1::Tuple{Vararg{Any, N}}) where {M, N}
+    subax1 = ntuple(Fix{1}(Base.getindex, ax1), Val(M))
+    eqs = _rmap(ax0, subax1) do x0, x1
+        isone(length(x0)) || x0 == x1
+    end
+    _rall(eqs)
 end
 
-@inline _checkaxes(::Union{Number,Base.RefValue}, _) = true
-@inline function _checkaxes(::Tuple{Vararg{Any,M}}, ax) where {M}
-  M == 1 || M == length(first(ax))
+@inline _checkaxes(::Union{Number, Base.RefValue}, _) = true
+@inline function _checkaxes(::Tuple{Vararg{Any, M}}, ax) where {M}
+    M == 1 || M == length(first(ax))
 end
 @inline function _checkaxes(B, ax)
-  _dynamic_match(static_axes(B), ax)
+    _dynamic_match(static_axes(B), ax)
 end
 @inline function _checkaxes(bc::Broadcasted, ax)
-  _rall(_rmap(Fix{2}(_checkaxes, ax), bc.args))
+    _rall(_rmap(Fix{2}(_checkaxes, ax), bc.args))
 end
 
-@inline _static_checkaxes(::Union{Number,Base.RefValue}, ::Tuple{Vararg{Any,N}}) where {N} = true, False()
-@inline function _static_checkaxes(::Tuple{Vararg{Any,M}}, ax::Tuple{Vararg{Any,N}}) where {M,N}
-  M == 1 || M == length(first(ax)), N == 1 ? False() : True()
+@inline _static_checkaxes(::Union{Number, Base.RefValue}, ::Tuple{Vararg{Any, N}}) where {N} = true,
+False()
+@inline function _static_checkaxes(
+        ::Tuple{Vararg{Any, M}}, ax::Tuple{Vararg{Any, N}}) where {M, N}
+    M == 1 || M == length(first(ax)), N == 1 ? False() : True()
 end
-@inline function _static_checkaxes(B, ax::Tuple{Vararg{Any,N}}) where {N}
-  bx = static_axes(B)
-  _static_match(bx, ax), (IndexStyle(typeof(B)) === IndexLinear()) && length(bx) == N ? _any_one(bx) : True()
+@inline function _static_checkaxes(B, ax::Tuple{Vararg{Any, N}}) where {N}
+    bx = static_axes(B)
+    _static_match(bx, ax),
+    (IndexStyle(typeof(B)) === IndexLinear()) && length(bx) == N ? _any_one(bx) : True()
 end
-@inline function _static_checkaxes(bc::Broadcasted, ax::Tuple{Vararg{Any,N}}) where {N}
-  tups = _rmap(Fix{2}(_static_checkaxes, ax), bc.args)
-  _rall(first, tups), _any(last, tups)
+@inline function _static_checkaxes(bc::Broadcasted, ax::Tuple{Vararg{Any, N}}) where {N}
+    tups = _rmap(Fix{2}(_static_checkaxes, ax), bc.args)
+    _rall(first, tups), _any(last, tups)
 end
 
 @inline function __fast_materialize!(dst, ::Val{true}, bc::Broadcasted, ::False)
-  @simd ivdep for i = eachindex(dst)
-    @inbounds dst[i] = _fastindex(bc, i)
-  end
-  return dst
+    @simd ivdep for i in eachindex(dst)
+        @inbounds dst[i] = _fastindex(bc, i)
+    end
+    return dst
 end
 @inline function __fast_materialize!(dst, ::Val{true}, bc::Broadcasted, ::True)
-  @simd ivdep for i = CartesianIndices(dst)
-    @inbounds dst[i] = _fastindex(bc, i)
-  end
-  return dst
+    @simd ivdep for i in CartesianIndices(dst)
+        @inbounds dst[i] = _fastindex(bc, i)
+    end
+    return dst
 end
 @inline function __fast_materialize!(dst, ::Val{false}, bc::Broadcasted, ::False)
-  for i = eachindex(dst)
-    @inbounds dst[i] = _fastindex(bc, i)
-  end
-  return dst
+    for i in eachindex(dst)
+        @inbounds dst[i] = _fastindex(bc, i)
+    end
+    return dst
 end
 @inline function __fast_materialize!(dst, ::Val{false}, bc::Broadcasted, ::True)
-  for i = CartesianIndices(dst)
-    @inbounds dst[i] = _fastindex(bc, i)
-  end
-  return dst
+    for i in CartesianIndices(dst)
+        @inbounds dst[i] = _fastindex(bc, i)
+    end
+    return dst
 end
 
-@inline function _fast_materialize!(dst, ::Val{NOALIAS}, ::False, bc::Broadcasted) where {NOALIAS}
-  _no_dyn_broadcast, _islinear = _static_checkaxes(bc, static_axes(dst))
-  @boundscheck _no_dyn_broadcast || throw(ArgumentError("Some axes are not equal, or feature a dynamic broadcast!"))
-  __fast_materialize!(dst, Val(NOALIAS), bc, _islinear)
-  return dst
+@inline function _fast_materialize!(
+        dst, ::Val{NOALIAS}, ::False, bc::Broadcasted) where {NOALIAS}
+    _no_dyn_broadcast, _islinear = _static_checkaxes(bc, static_axes(dst))
+    @boundscheck _no_dyn_broadcast ||
+                 throw(ArgumentError("Some axes are not equal, or feature a dynamic broadcast!"))
+    __fast_materialize!(dst, Val(NOALIAS), bc, _islinear)
+    return dst
 end
 
-@inline function _fast_materialize!(dst, ::Val{NOALIAS}, ::True, bc::Broadcasted) where {NOALIAS}
-  _no_dyn_broadcast, _islinear = _static_checkaxes(bc, static_axes(dst))
-  _no_dyn_broadcast && return __fast_materialize!(dst, Val(NOALIAS), bc, _islinear)
-  @boundscheck _checkaxes(bc, static_axes(dst)) || throw(ArgumentError("Size mismatch."))
-  _slow_materialize!(dst, Val(NOALIAS), bc)
+@inline function _fast_materialize!(
+        dst, ::Val{NOALIAS}, ::True, bc::Broadcasted) where {NOALIAS}
+    _no_dyn_broadcast, _islinear = _static_checkaxes(bc, static_axes(dst))
+    _no_dyn_broadcast && return __fast_materialize!(dst, Val(NOALIAS), bc, _islinear)
+    @boundscheck _checkaxes(bc, static_axes(dst)) || throw(ArgumentError("Size mismatch."))
+    _slow_materialize!(dst, Val(NOALIAS), bc)
 end
 
 function _slow_materialize!(
-  dst,
-  ::Val{true},
-  bc::Broadcasted,
+        dst,
+        ::Val{true},
+        bc::Broadcasted
 )
-  @simd ivdep for i = CartesianIndices(dst)
-    @inbounds dst[i] = _slowindex(bc, i)
-  end
-  return dst
+    @simd ivdep for i in CartesianIndices(dst)
+        @inbounds dst[i] = _slowindex(bc, i)
+    end
+    return dst
 end
 function _slow_materialize!(
-  dst,
-  ::Val{false},
-  bc::Broadcasted,
+        dst,
+        ::Val{false},
+        bc::Broadcasted
 )
-  for i = CartesianIndices(dst)
-    @inbounds dst[i] = _slowindex(bc, i)
-  end
-  return dst
+    for i in CartesianIndices(dst)
+        @inbounds dst[i] = _slowindex(bc, i)
+    end
+    return dst
 end
 
-Base.@propagate_inbounds function fast_materialize(::SB, ::DB, bc::Broadcasted{S}) where {S,SB,DB}
-  if use_fast_broadcast(S)
-    fast_materialize!(SB(), DB(), similar(bc, Base.Broadcast.combine_eltypes(bc.f, bc.args)), bc,)
-  else
-    Base.Broadcast.materialize(bc)
-  end
+Base.@propagate_inbounds function fast_materialize(
+        ::SB, ::DB, bc::Broadcasted{S}) where {S, SB, DB}
+    if use_fast_broadcast(S)
+        fast_materialize!(
+            SB(), DB(), similar(bc, Base.Broadcast.combine_eltypes(bc.f, bc.args)), bc)
+    else
+        Base.Broadcast.materialize(bc)
+    end
 end
 use_fast_broadcast(_) = false
 use_fast_broadcast(::Type{<:Base.Broadcast.DefaultArrayStyle}) = true
 use_fast_broadcast(::Type{<:Base.Broadcast.DefaultArrayStyle{0}}) = false
 
-
-Base.@propagate_inbounds function fast_materialize!(::False, ::DB, dst::A, bc::Broadcasted{S}) where {S,DB,A}
-  if use_fast_broadcast(S)
-    _fast_materialize!(dst, Val(indices_do_not_alias(A)), DB(), bc,)
-  else
-    Base.Broadcast.materialize!(dst, bc)
-  end
+Base.@propagate_inbounds function fast_materialize!(
+        ::False, ::DB, dst::A, bc::Broadcasted{S}) where {S, DB, A}
+    if use_fast_broadcast(S)
+        _fast_materialize!(dst, Val(indices_do_not_alias(A)), DB(), bc)
+    else
+        Base.Broadcast.materialize!(dst, bc)
+    end
 end
 
-@inline _view(A::AbstractArray{<:Any,N}, r, ::Val{N}) where {N} =
-  view(A, ntuple(_ -> :, N - 1)..., r)
+@inline _view(A::AbstractArray{<:Any, N}, r, ::Val{N}) where {N} = view(
+    A, ntuple(_ -> :, N - 1)..., r)
 @inline _view(A::AbstractArray, r, ::Val) = A
 @inline _view(x, r, ::Val) = x
-@inline __view(t::Tuple{T}, r, ::Val{N}) where {T,N} = (_view(first(t), r, Val(N)),)
-@inline __view(t::Tuple{T,Vararg}, r, ::Val{N}) where {T,N} =
-  (_view(first(t), r, Val(N)), __view(Base.tail(t), r, Val(N))...)
-@inline function _view(bc::Base.Broadcast.Broadcasted{<:Base.Broadcast.AbstractArrayStyle{N},Nothing}, r, ::Val{N},) where {N}
-  Base.Broadcast.Broadcasted(bc.f, __view(bc.args, r, Val(N)))
+@inline __view(t::Tuple{T}, r, ::Val{N}) where {T, N} = (_view(first(t), r, Val(N)),)
+@inline __view(t::Tuple{T, Vararg}, r, ::Val{N}) where {T, N} = (
+    _view(first(t), r, Val(N)), __view(Base.tail(t), r, Val(N))...)
+@inline function _view(
+        bc::Base.Broadcast.Broadcasted{<:Base.Broadcast.AbstractArrayStyle{N}, Nothing},
+        r, ::Val{N}) where {N}
+    Base.Broadcast.Broadcasted(bc.f, __view(bc.args, r, Val(N)))
 end
-@inline _view(bc::Base.Broadcast.Broadcasted{<:Base.Broadcast.AbstractArrayStyle}, _, ::Val{N},) where {N} = bc
-@inline _view(t::Tuple{Vararg{AbstractRange,N}}, r, ::Val{N}) where {N} = (Base.front(t)..., r)
+@inline _view(bc::Base.Broadcast.Broadcasted{<:Base.Broadcast.AbstractArrayStyle}, _, ::Val{N}) where {N} = bc
+@inline _view(t::Tuple{Vararg{AbstractRange, N}}, r, ::Val{N}) where {N} = (
+    Base.front(t)..., r)
 
-@inline function fast_materialize!(::True, ::DB, dst, bc::Broadcasted{S}) where {S,DB}
-  if use_fast_broadcast(S)
-    fast_materialize_threaded!(dst, DB(), bc, static_axes(dst))
-  else
-    Base.Broadcast.materialize!(dst, bc)
-  end
+@inline function fast_materialize!(::True, ::DB, dst, bc::Broadcasted{S}) where {S, DB}
+    if use_fast_broadcast(S)
+        fast_materialize_threaded!(dst, DB(), bc, static_axes(dst))
+    else
+        Base.Broadcast.materialize!(dst, bc)
+    end
 end
 @inline function _batch_broadcast_fn((dest, ldstaxes, bcobj, VN, DoBroadcast), start, stop)
-  r = @inbounds ldstaxes[start:stop]
-  fast_materialize!(False(), DoBroadcast, _view(dest, r, VN), _view(bcobj, r, VN))
-  return nothing
+    r = @inbounds ldstaxes[start:stop]
+    fast_materialize!(False(), DoBroadcast, _view(dest, r, VN), _view(bcobj, r, VN))
+    return nothing
 end
 @inline function fast_materialize_threaded!(
-  dst,
-  ::DB,
-  bc::Broadcasted,
-  dstaxes::Tuple{Vararg{Any,N}},
-) where {N,DB}
-  last_dstaxes = dstaxes[N]
-  Polyester.batch(_batch_broadcast_fn, (length(last_dstaxes), Threads.nthreads()), dst, last_dstaxes, bc, Val(N), DB())
-  return dst
+        dst,
+        ::DB,
+        bc::Broadcasted,
+        dstaxes::Tuple{Vararg{Any, N}}
+) where {N, DB}
+    last_dstaxes = dstaxes[N]
+    Polyester.batch(_batch_broadcast_fn, (length(last_dstaxes), Threads.nthreads()),
+        dst, last_dstaxes, bc, Val(N), DB())
+    return dst
 end
+fast_materialize!(_, _, dst, x::Number) = fill!(dst, x)
 
-
-
-function pushsymname!(ex::Expr, base::Symbol, @nospecialize(arg))
-  if arg isa Core.SSAValue
-    push!(ex.args, Symbol(base, '_', arg.id))
-  elseif arg isa Core.SlotNumber
-    push!(ex.args, Symbol(base, 's', arg.id))
-  else
-    push!(ex.args, arg)
-  end
-end
-function _goto(base::Symbol, i::Int, sym::Symbol)
-  Expr(
-    :macrocall,
-    sym,
-    LineNumberNode(@__LINE__, Symbol(@__FILE__)),
-    Symbol(base, "#label#", i),
-  )
-end
-goto(base::Symbol, i::Int) = _goto(base, i, Symbol("@goto"))
-label(base::Symbol, i::Int) = _goto(base, i, Symbol("@label"))
-
-function gotoifnot_stmt(base::Symbol, cond, dest::Int)
-  ex = Expr(:||)
-  pushsymname!(ex, base, cond)
-  push!(ex.args, goto(base, dest))
-  return ex
-end
-function _push_static_bool!(ex::Expr, b)
-  if !(b isa Bool)
-    push!(ex.args, b)
-  elseif b
-    push!(ex.args, True())
-  else
-    push!(ex.args, False())
-  end
-end
-
-function broadcast_stmt!(gotos::Vector{Int}, base::Symbol, i::Int,
-  threadarg, broadcastarg, @nospecialize(code))
-  if Meta.isexpr(code, :call)
-    ex = Expr(:call)
-    f = code.args[1]
-    if f === GlobalRef(Base, :materialize)
-      push!(ex.args, fast_materialize)
-      _push_static_bool!(ex, threadarg)
-      _push_static_bool!(ex, broadcastarg)
-    elseif f === GlobalRef(Base, :materialize!)
-      push!(ex.args, fast_materialize!)
-      _push_static_bool!(ex, threadarg)
-      _push_static_bool!(ex, broadcastarg)
-    elseif f === GlobalRef(Base, :getindex)
-      push!(ex.args, Base.Broadcast.dotview)
+function _pushfirst_static!(x, b)
+    if !(b isa Bool)
+        pushfirst!(x, b)
+    elseif b
+        pushfirst!(x, True())
     else
-      pushsymname!(ex, base, f)
+        pushfirst!(x, False())
     end
-    for arg ∈ @view(code.args[2:end])
-      pushsymname!(ex, base, arg)
-    end
-    return Expr(:(=), Symbol(base, '_', i), ex)
-  elseif Meta.isexpr(code, :(=))
-    ex = Expr(:(=), Symbol(base, 's', code.args[1].id))
-    rhs = broadcast_stmt!(gotos, base, i, threadarg, broadcastarg, code.args[2])
-    pushsymname!(ex, base, rhs)
-    return ex
-  elseif VERSION ≥ v"1.6" && code isa Core.GotoIfNot
-    push!(gotos, code.dest)
-    return gotoifnot_stmt(base, code.cond, code.dest)
-  elseif VERSION < v"1.6" && Meta.isexpr(code, :gotoifnot)
-    cond, dest = code.args
-    push!(gotos, dest)
-    return gotoifnot_stmt(base, cond, dest)
-  elseif code isa Core.GotoNode
-    push!(gotos, code.label)
-    ex = goto(base, code.label)
-    return ex
-  elseif !(VERSION ≥ v"1.6" ? isa(code, Core.ReturnNode) : Meta.isexpr(code, :return))
-    ex = Expr(:(=), Symbol(base, '_', i))
-    pushsymname!(ex, base, code)
-    return ex
-  end
-  return nothing
 end
 
-function broadcast_codeinfo(ci, threadarg, broadcastarg)
-  q = Expr(:block)
-  base = gensym(:fastbroadcast)
-  gotos = Int[]
-  for (i, code) ∈ enumerate(ci.code)
-    k = findfirst(==(i), gotos)
-    if k ≢ nothing
-      push!(q.args, label(base, i))
-    end
-    ex = broadcast_stmt!(gotos, base, i, threadarg, broadcastarg, code)
-    if ex !== nothing
-      push!(q.args, ex)
-    end
-  end
-  q
+@inline _broadcasted(f::F, args...) where {F} = Base.Broadcast.broadcasted(f, args...)
+@inline _broadcasted(::Colon, arg0, arg1) = arg0:arg1
+@inline _broadcasted(::typeof(Base.maybeview), args...) = begin
+    Base.maybeview(args...)
 end
 
-function fb_macro(ex::Expr, mod::Module, threadarg, broadcastarg)
-  lowered = Meta.lower(mod, Base.Broadcast.__dot__(ex))
-  lowered isa Expr || return esc(lowered)
-  esc(broadcast_codeinfo(lowered.args[1], threadarg, broadcastarg))
+function _fb_macro!(ex::Expr, threadarg, broadcastarg)
+    ops = (:(+), :(-), :(*), :(/), :(\), :(÷), :(&),
+        :(|), :(⊻), :(>>), :(>>>), :(<<))
+    if Meta.isexpr(ex, :(.)) && length(ex.args) == 2
+        args = ex.args[2]
+        args isa QuoteNode && return
+        resize!(ex.args, 1)
+        ex.head = :call
+        append!(ex.args, args.args)
+    end
+    skip = 0
+    if Meta.isexpr(ex, :call)
+        if Meta.isexpr(ex.args[1], :($))
+            ex.args[1] = only(ex.args[1].args)
+            return
+        elseif ex.args[1] == :(:)
+            return
+        end
+        pushfirst!(ex.args, _broadcasted)
+        ind = Base.findfirst(
+            ==(ex.args[2]), (Symbol(".+"), Symbol(".-"), Symbol(".*"),
+                Symbol("./"), Symbol(".\\"), Symbol(".÷"), Symbol(".&"),
+                Symbol(".|"), Symbol(".⊻"), Symbol(".>>"), Symbol(".>>>"), Symbol(".<<")))
+        if ind !== nothing
+            ex.args[2] = ops[ind]
+        end
+    elseif Meta.isexpr(ex, :(=))
+        ex.head = :call
+        _pushfirst_static!(ex.args, broadcastarg)
+        _pushfirst_static!(ex.args, threadarg)
+        pushfirst!(ex.args, fast_materialize!)
+        a4 = ex.args[4]
+        if Meta.isexpr(a4, :ref)
+            a4.head = :call
+            pushfirst!(a4.args, Base.maybeview)
+            skip = 4
+        end
+    elseif Meta.isexpr(ex, :($), 1)
+        if (exarg = only(ex.args); exarg isa Expr)
+            ex.head = exarg.head
+            ex.args = exarg.args
+            return
+        end
+    elseif Meta.isexpr(ex, :let)
+        skip = 1
+    else
+        ind = Base.findfirst(
+            ==(ex.head), (:(+=), :(-=), :(*=), :(/=), :(\=), :(÷=), :(&=),
+                :(|=), :(⊻=), :(>>=), :(>>>=), :(<<=)))
+        if ind !== nothing
+            op = ops[ind]
+            # x op= f(args...) -> x = op(x, f(args...))
+            @assert length(ex.args) == 2
+            ex.args[2] = Expr(:call, op, ex.args[1], ex.args[2])
+            ex.head = :(=)
+            return _fb_macro!(ex, threadarg, broadcastarg)
+        end
+    end
+    for i in (1 + skip):length(ex.args)
+        x = ex.args[i]
+        x isa Expr &&
+            _fb_macro!(x, threadarg, broadcastarg)
+    end
+end
+function fb_macro!(ex::Expr, threadarg, broadcastarg)
+    iscall = Meta.isexpr(ex, :call)
+    _fb_macro!(ex, threadarg, broadcastarg)
+    if iscall
+        ex = Expr(:call, ex)
+        _pushfirst_static!(ex.args, broadcastarg)
+        _pushfirst_static!(ex.args, threadarg)
+        pushfirst!(ex.args, fast_materialize)
+    end
+    esc(ex)
 end
 
 """
@@ -369,45 +371,45 @@ It additionally provides two optional keyword arguments:
     base broadcasting only supports `broadcast=true`.
 """
 macro (..)(ex)
-  ex isa Expr || return esc(ex)
-  fb_macro(ex, __module__, false, false)
+    ex isa Expr || return esc(ex)
+    fb_macro!(ex, false, false)
 end
 
 function __process_kwarg(kwarg)
-  kwarg.args[2]
+    kwarg.args[2]
 end
 function _validate_kwarg(kwarg)
-  @assert Meta.isexpr(kwarg, :(=), 2)
-  argname = kwarg.args[1]
-  @assert (argname === :thread) || (argname === :broadcast)
-  argname === :thread
+    @assert Meta.isexpr(kwarg, :(=), 2)
+    argname = kwarg.args[1]
+    @assert (argname === :thread) || (argname === :broadcast)
+    argname === :thread
 end
-function _process_kwarg(kwarg, threadarg=false, broadcastarg=false)
-  if _validate_kwarg(kwarg)
-    return __process_kwarg(kwarg), broadcastarg
-  else
-    return threadarg, __process_kwarg(kwarg)
-  end
+function _process_kwarg(kwarg, threadarg = false, broadcastarg = false)
+    if _validate_kwarg(kwarg)
+        return __process_kwarg(kwarg), broadcastarg
+    else
+        return threadarg, __process_kwarg(kwarg)
+    end
 end
 
 macro (..)(kwarg, ex)
-  threadarg, broadcastarg = _process_kwarg(kwarg)
-  fb_macro(ex, __module__, threadarg, broadcastarg)
+    threadarg, broadcastarg = _process_kwarg(kwarg)
+    fb_macro!(ex, threadarg, broadcastarg)
 end
 macro (..)(kwarg0, kwarg1, ex)
-  threadarg, broadcastarg = _process_kwarg(kwarg0)
-  threadarg, broadcastarg = _process_kwarg(kwarg1, threadarg, broadcastarg)
-  fb_macro(ex, __module__, threadarg, broadcastarg)
+    threadarg, broadcastarg = _process_kwarg(kwarg0)
+    threadarg, broadcastarg = _process_kwarg(kwarg1, threadarg, broadcastarg)
+    fb_macro!(ex, threadarg, broadcastarg)
 end
 
 let # we could check `hasfield(Method, :recursion_relation)`, but I'd rather see an error if things change
-  dont_limit = Returns(true)
-  for f in (_fastindex, _slowindex, _checkaxes, _static_checkaxes, __any, _any, __all, _all, _rall, _rmap, __view, _view)
-    for m in methods(f)
-      m.recursion_relation = dont_limit
+    dont_limit = Returns(true)
+    for f in (_fastindex, _slowindex, _checkaxes, _static_checkaxes,
+        __any, _any, __all, _all, _rall, _rmap, __view, _view)
+        for m in methods(f)
+            m.recursion_relation = dont_limit
+        end
     end
-  end
 end
-
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,6 @@ using FastBroadcast
 using SparseArrays
 using PerformanceTestTools, Test
 
-FastBroadcast.DEBUG[] = true
-
 const GROUP = get(ENV, "GROUP", "All")
 
 function activate_downstream_env()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,29 +20,28 @@ if GROUP == "All" || GROUP == "Core"
             FastBroadcast.False(),
             FastBroadcast.True(),
             dst,
-            bc,
+            bc
         ) == bcref
         @test FastBroadcast.fast_materialize!(
             FastBroadcast.False(),
             FastBroadcast.False(),
             dst,
-            bc,
+            bc
         ) == bcref
         dest = similar(bcref)
         @test (@.. dest = (x * y) + x + y + x + y + x + y) == bcref
         @test (@.. (x * y) + x + y + x + y + x + y) == bcref
-        @test (@.. thread = true dest .+= (x * y) + x + y + x + y + x + y) ≈ 2bcref
+        @test (@.. thread=true dest.+=(x * y) + x + y + x + y + x + y) ≈ 2bcref
         @test (@.. dest .-= (x * y) + x + y + x + y + x + y) ≈ bcref
-        @test (@.. thread = true dest *= (x * y) + x + y + x + y + x + y) ≈ abs2.(bcref)
+        @test (@.. thread=true dest*=(x * y) + x + y + x + y + x + y) ≈ abs2.(bcref)
 
-        @test (@.. broadcast = false dest = (x * y) + x + y + x + y + x + y) == bcref
-        @test (@.. broadcast = false (x * y) + x + y + x + y + x + y) == bcref
-        @test (@.. broadcast = false thread = true dest .+=
-            (x * y) + x + y + x + y + x + y) ≈ 2bcref
-        @test (@.. broadcast = false dest .-= (x * y) + x + y + x + y + x + y) ≈ bcref
-        @test (@.. broadcast = false thread = true dest *=
-            (x * y) + x + y + x + y + x + y) ≈ abs2.(bcref)
-
+        @test (@.. broadcast=false dest=(x * y) + x + y + x + y + x + y) == bcref
+        @test (@.. broadcast=false (x*y)+x+y+x+y+x+y) == bcref
+        @test (@.. broadcast=false thread=true dest.+=(x * y) + x + y + x + y + x + y) ≈
+              2bcref
+        @test (@.. broadcast=false dest.-=(x * y) + x + y + x + y + x + y) ≈ bcref
+        @test (@.. broadcast=false thread=true dest*=(x * y) + x + y + x + y + x + y) ≈
+              abs2.(bcref)
 
         nt = (x = x,)
         @test (@.. (nt.x * y) + x + y + x * (3, 4, 5, 6) + y + x * (1,) + y + 3) ≈
@@ -51,8 +50,8 @@ if GROUP == "All" || GROUP == "Core"
         @test (@.. A * y' + x) ≈ (@. A * y' + x)
         @test (@.. A * transpose(y) + x) ≈ (@. A * transpose(y) + x)
         Ashim = A[1:1, :]
-        @test_throws ArgumentError (@.. Ashim * y' + x) ≈ (@. Ashim * y' + x) # test fallback
-        @test (@.. broadcast=true Ashim * y' + x) ≈ (@. Ashim * y' + x) # test fallback
+        @test_throws ArgumentError (@.. Ashim * y' + x)≈(@. Ashim * y' + x) # test fallback
+        @test (@.. broadcast=true Ashim * y'+x) ≈ (@. Ashim * y' + x) # test fallback
         Av = view(A, 1, :)
         @test (@.. Av * y' + A) ≈ (@. Av * y' + A)
         B = similar(A)
@@ -73,7 +72,7 @@ if GROUP == "All" || GROUP == "Core"
         @static if VERSION >= v"1.6"
             var".foo"(a) = a
             @views @.. a = var".foo".(b[1:2]) .+ $abs2(c)
-            @views @.. thread = true a = var".foo".(b[1:2]) .+ $(abs2(c))
+            @views @.. thread=true a=var".foo".(b[1:2]) .+ $(abs2(c))
             @test a == [4, 6]
         else
             a = [4, 6]
@@ -111,14 +110,16 @@ if GROUP == "All" || GROUP == "Core"
             C = similar(A)
             d = rand(N)
             dt = transpose(d)  # could also use permutedims, same problem
-            @.. thread = true broadcast = false C = A * dt
+            @.. thread=true broadcast=false C=A * dt
             @test C ≈ A .* dt
-            @test_throws ArgumentError @.. broadcast = false A * [1.0]
+            @test_throws ArgumentError @.. broadcast=false A*[1.0]
         end
         @test FastBroadcast.indices_do_not_alias(typeof(view(fill(0, 10), 1:4)))
 
-        let ex = macroexpand(@__MODULE__, :(@.. broadcast=false @view(J[idxs])=@view(J[idxs]) - inv_alpha))
-            @test Base.Meta.isexpr(ex, :block)
+        let ex = macroexpand(@__MODULE__,
+                :(@.. broadcast=false @view(J[idxs])=@view(J[idxs]) - inv_alpha))
+            @test Base.Meta.isexpr(ex, :call)
+            @test ex.args[1] === FastBroadcast.fast_materialize!
         end
     end
 


### PR DESCRIPTION
Times on an unreliable laptop with dynamic boosting behavior; master branch:
```julia
julia> @time include("src/OrdinaryDiffEq.jl")
 22.377542 seconds (19.12 M allocations: 1.169 GiB, 1.69% gc time, 34.02% compilation time: <1% of which was recompilation)
Main.OrdinaryDiffEq
```
With the PR:
```sh
> julia -O3 -Cnative,-prefer-256-bit -q --project=.
```
```julia
julia> @time include("src/OrdinaryDiffEq.jl")
 15.230578 seconds (18.13 M allocations: 1.121 GiB, 2.18% gc time, 36.50% compilation time: <1% of which was recompilation)
Main.OrdinaryDiffEq

julia> exit()
```
```sh
> julia -O3 -Cnative,-prefer-256-bit -q --project=.
```
```julia
julia> @time include("src/OrdinaryDiffEq.jl")
 15.355708 seconds (18.14 M allocations: 1.121 GiB, 2.21% gc time, 36.52% compilation time: <1% of which was recompilation)
Main.OrdinaryDiffEq

julia> exit()
```
```sh
> julia -O3 -Cnative,-prefer-256-bit -q --project=.
```
```julia
julia> @time include("src/OrdinaryDiffEq.jl")
 15.079409 seconds (18.14 M allocations: 1.121 GiB, 2.18% gc time, 36.82% compilation time: <1% of which was recompilation)
Main.OrdinaryDiffEq
```

I commented out the `PrecompileTools.@compile_workload begin` block of OrdinaryDiffEq, as the `Preferences.@load_preference` don't work when including that file into `Main` instead of loading it as a package like one normally would.