### PR TITLE
explicitly test that `@..` fails with `DimensionMismatch` when dimmensions don't match

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -135,7 +135,9 @@ if GROUP == "All" || GROUP == "Core"
       @test ex.args[1] === FastBroadcast.fast_materialize!
     end
   end
-
+  A = rand(4,2)
+  v = rand(8)
+  @test_throws Base.DimensionMismatch @.. A = v
   VERSION >= v"1.6" && PerformanceTestTools.@include("vectorization_tests.jl")
 end
 


### PR DESCRIPTION
This was a bug in 0.2.8 that some parts of sciml relied on so it would be good to make sure we don't re-introduce this bug.