### PR TITLE
Adapt URL for CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FastBroadcast
 
-[![Build Status](https://github.com/YingboMa/FastBroadcast.jl/workflows/CI/badge.svg)](https://github.com/YingboMa/FastBroadcast.jl/actions)
+[![Build Status](https://github.com/YingboMa/FastBroadcast.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/YingboMa/FastBroadcast.jl/actions?query=workflow%3ACI)
 [![Coverage](https://codecov.io/gh/YingboMa/FastBroadcast.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/YingboMa/FastBroadcast.jl)
 
 FastBroadcast.jl exports `@..` that compiles broadcast expressions into loops


### PR DESCRIPTION
The badge in the README.md showed failing CI although the last CI runs passed. I adapted the badge URL according to the scheme in the docs https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name Now, everything is green for me.