### PR TITLE
Fix silent no-op on fancy-indexed LHS in `@..` (fixes #89)

### DIFF
--- a/src/FastBroadcast.jl
+++ b/src/FastBroadcast.jl
@@ -373,7 +373,14 @@ function _fb_macro!(ex::Expr, threadarg, broadcastarg)
         a4 = ex.args[end]
         if Meta.isexpr(a4, :ref)
             _view!(a4)
-            skip = 4
+            # Also wrap a `:ref` LHS in `@views` so fancy/range indexed assignment
+            # writes to the underlying array. Otherwise `temp[diff] = data[diff]`
+            # passes a `getindex` copy as dst and silently drops the write.
+            a3 = ex.args[end - 1]
+            if Meta.isexpr(a3, :ref)
+                _view!(a3)
+            end
+            skip = length(ex.args)
         end
     elseif Meta.isexpr(ex, :($), 1)
         if (exarg = only(ex.args); exarg isa Expr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,6 +85,14 @@ if GROUP == "All" || GROUP == "Core"
         @test r == [5, 6, 25, 35]
         @test (@.. r + r[end]) == [40, 41, 60, 70]
 
+        # Issue #89: fancy indexing on LHS must write through (not silently copy).
+        let temp = [0.0, 0.0], data = [1.0, 1.0]
+            @.. temp[[2]] = data[[2]]
+            @test temp == [0.0, 1.0]
+            @.. temp[[1]] = data[[1]]
+            @test temp == [1.0, 1.0]
+        end
+
         let
             @.. x = y
             @test x == y


### PR DESCRIPTION
## Summary

Fixes #89. `@.. temp[diff] = data[diff]` silently dropped the write on v1+.

## Root cause

In `_fb_macro!` (`src/FastBroadcast.jl`), the `:(=)` branch wrapped only the RHS `:ref` in `@views` and then set `skip` high enough to stop recursion, so an LHS `:ref` was left as a plain `getindex`. The macro expanded to:

```julia
fast_materialize!(Serial(), temp[diff], maybeview(data, diff))
```

`temp[diff]` on the RHS of the call is `getindex`, which returns a **copy**. `copyto!` wrote into the copy and the original `temp` was untouched — silent no-op.

## Fix

Also `_view!` the LHS when it's a `:ref`, so both sides go through `Base.maybeview`:

```julia
fast_materialize!(Serial(), maybeview(temp, diff), maybeview(data, diff))
```

This matches Base `@.` semantics for indexed assignment (auto-fallback rather than erroring — fancy-indexed LHS now just works).

## Test plan

- [x] Added regression test mirroring the MWE from #89 (`temp[[1]] = data[[1]]`, etc.)
- [x] Existing test suite still passes (55/55 locally)
- [ ] CI green

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)