### PR TITLE
Add Polyester error hint for `@.. thread=true`

### DIFF
--- a/src/FastBroadcast.jl
+++ b/src/FastBroadcast.jl
@@ -258,6 +258,21 @@ to be loaded (which activates the FastBroadcastPolyesterExt extension).
 """
 function fast_materialize_threaded! end
 
+function __init__()
+    return Base.Experimental.register_error_hint(MethodError) do io, exc, _argtypes, _kwargs
+        if exc.f === fast_materialize_threaded || exc.f === fast_materialize_threaded!
+            if Base.get_extension(@__MODULE__, :FastBroadcastPolyesterExt) === nothing
+                print(
+                    io,
+                    "\n\n`@.. thread=true` (and `FastBroadcast.fast_materialize_threaded`/",
+                    "`fast_materialize_threaded!`) requires the Polyester.jl package to be loaded. ",
+                    "Run `using Polyester` (or `import Polyester`) to load the ",
+                    "FastBroadcastPolyesterExt extension."
+                )
+            end
+        end
+    end
+end
 
 
 _dim0(_) = false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -159,6 +159,30 @@ if GROUP == "All" || GROUP == "Core"
             @test_throws DimensionMismatch @.. a = A
             @test_throws DimensionMismatch @.. a += A
         end
+
+        @testset "Polyester error hint (issue #91)" begin
+            # Run a fresh Julia process that loads FastBroadcast without Polyester,
+            # trigger `@.. thread=true`, and check that the MethodError shows a hint
+            # pointing the user to `using Polyester`.
+            script = """
+                push!(LOAD_PATH, $(repr(dirname(Base.active_project()))))
+                using FastBroadcast
+                @assert Base.get_extension(FastBroadcast, :FastBroadcastPolyesterExt) === nothing
+                xs = [1.0, 2.0, 3.0]
+                try
+                    @.. thread=true sin(xs)
+                    error("expected MethodError but call succeeded")
+                catch err
+                    err isa MethodError || rethrow()
+                    io = IOBuffer()
+                    Base.showerror(io, err)
+                    msg = String(take!(io))
+                    occursin("using Polyester", msg) || error("hint missing:\\n" * msg)
+                end
+            """
+            cmd = `$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) -e $script`
+            @test success(pipeline(cmd; stdout = stdout, stderr = stderr))
+        end
     end
     A = rand(4, 2)
     v = rand(8)


### PR DESCRIPTION
## Summary

- Closes #91.
- Registers a `Base.Experimental.register_error_hint(MethodError, …)` handler in `FastBroadcast.__init__` that fires when `fast_materialize_threaded` or `fast_materialize_threaded!` hits a `MethodError` while the `FastBroadcastPolyesterExt` extension is not loaded. The hint tells the user to run `using Polyester` (or `import Polyester`).
- Adds a regression test that spawns a fresh Julia subprocess without `using Polyester`, triggers `@.. thread=true sin(xs)`, captures `Base.showerror` output, and asserts the hint text is present.

## Why

Before this PR, `@.. thread=true` with Polyester not loaded produced a raw `MethodError: no method matching fast_materialize_threaded(::Broadcasted...)` with no indication that the user just needs to load the Polyester extension — the exact complaint in #91.

## Behavior

- Polyester **not** loaded → `Base.showerror` prints the normal `MethodError` followed by: `` `@.. thread=true` (and `FastBroadcast.fast_materialize_threaded`/`fast_materialize_threaded!`) requires the Polyester.jl package to be loaded. Run `using Polyester` (or `import Polyester`) to load the FastBroadcastPolyesterExt extension. ``
- Polyester loaded → hint stays silent (guarded by `Base.get_extension(...) === nothing`), so genuine `MethodError`s from unexpected argument types aren't polluted with a misleading suggestion.

## Test plan

- [x] `Pkg.test()` → 56/56 pass, including the new `Polyester error hint (issue #91)` testset.
- [x] Manually verified the hint text appears only when Polyester is not loaded.
- [x] Runic-clean (`src/FastBroadcast.jl`, `test/runtests.jl`).