### PR TITLE
Centralize CI: add SpellCheck and Downgrade reusable-workflow callers

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -1,0 +1,20 @@
+name: Downgrade
+on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+
+jobs:
+  downgrade:
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "lts"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,0 +1,12 @@
+name: SpellCheck
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  spellcheck:
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas

## What this does

Completes the migration of this repo's CI to the centralized SciML reusable workflows so the end-state matches the standard (Tests, Runic, SpellCheck, Downgrade, Downstream — all via central callers; no Documentation since there is no `docs/`).

### Already centralized (left unchanged)
- **Tests** — `CI.yml` already calls `tests.yml@v1` (matrix `lts`/`1`/`pre`).
- **Downstream** — `Downstream.yml` already calls `downstream.yml@v1` (DiffEqBase.jl, group All).
- **Runic** — `FormatCheck.yml` already calls `runic.yml@v1`.
- All existing callers already use `secrets: "inherit"`.

### Added (new central callers)
- **SpellCheck.yml** → `spellcheck.yml@v1`
- **Downgrade.yml** → `downgrade.yml@v1` (`julia-version: lts`, `skip: Pkg,TOML`)

Both new callers use `secrets: "inherit"`.

### Formatting / typos
- Ran Runic in-place: **no changes** (already clean).
- Ran `typos`: **0 fixes**, clean.

### Notes
- `dependabot.yml` already has both the `github-actions` (`/`, weekly) and `julia` (dirs `/` and `/test/downstream`, daily, group `all-julia-packages: ["*"]`) blocks; left unchanged.
- No CompatHelper.yml present. TagBot.yml unchanged.

⚠️ Branch-protection required checks will gain new check names (SpellCheck, Downgrade) — required-check settings may need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)