### PR TITLE
Canonicalize tests around @safetestset (isolation, matches OrdinaryDiffEq)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,6 +21,7 @@ InteractiveUtils = "1"
 MuladdMacro = "0.2"
 PerformanceTestTools = "0.1"
 Polyester = "0.5, 0.6, 0.7"
+SafeTestsets = "0.1, 1"
 SparseArrays = "1"
 Static = "1"
 Test = "1"
@@ -32,9 +33,10 @@ MuladdMacro = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
 PerformanceTestTools = "dc46b164-d16f-48ec-a853-60448fc869fe"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["InteractiveUtils", "MuladdMacro", "PerformanceTestTools", "Pkg", "Polyester", "SparseArrays", "Static", "Test"]
+test = ["InteractiveUtils", "MuladdMacro", "PerformanceTestTools", "Pkg", "Polyester", "SafeTestsets", "SparseArrays", "Static", "Test"]

--- a/test/core_tests.jl
+++ b/test/core_tests.jl
@@ -1,0 +1,175 @@
+using FastBroadcast
+using Polyester  # loads FastBroadcastPolyesterExt
+using SparseArrays
+using Test
+
+x, y = [1, 2, 3, 4], [5, 6, 7, 8]
+dst = zeros(Int, 4)
+bc = Broadcast.Broadcasted(+, (Broadcast.Broadcasted(*, (x, y)), x, y, x, y, x, y))
+bcref = copy(bc)
+@test FastBroadcast.fast_materialize_threaded!(
+    dst,
+    bc,
+) == bcref
+@test FastBroadcast.fast_materialize!(
+    FastBroadcast.Serial(),
+    dst,
+    bc,
+) == bcref
+dest = similar(bcref)
+@test (@.. dest = (x * y) + x + y + x + y + x + y) == bcref
+@test (@.. (x * y) + x + y + x + y + x + y) == bcref
+@test (@.. thread = true dest .+= (x * y) + x + y + x + y + x + y) ≈ 2bcref
+destwrap = [dest]
+@test (@.. destwrap[end] .-= (x * y) + x + y + x + y + x + y) ≈ bcref
+@test (@.. thread = true dest *= (x * y) + x + y + x + y + x + y) ≈ abs2.(bcref)
+
+@test (@.. broadcast = false destwrap[end] = (x * y) + x + y + x + y + x + y) == bcref
+@test (@.. broadcast = false (x * y) + x + y + x + y + x + y) == bcref
+@test (@.. broadcast = false thread = true dest .+= (x * y) + x + y + x + y + x + y) ≈
+    2bcref
+@test (@.. broadcast = false dest .-= (x * y) + x + y + x + y + x + y) ≈ bcref
+@test (@.. broadcast = false thread = true dest *= (x * y) + x + y + x + y + x + y) ≈
+    abs2.(bcref)
+
+nt = (x = x,)
+@test (@.. (nt.x * y) + x + y + x * (3, 4, 5, 6) + y + x * (1,) + y + 3) ≈
+    (@. (x * y) + x + y + x * (3, 4, 5, 6) + y + nt.x * (1,) + y + 3)
+A = rand(4, 4)
+@test (@.. A * y' + x) ≈ (@. A * y' + x)
+@test (@.. A * transpose(y) + x) ≈ (@. A * transpose(y) + x)
+Ashim = A[1:1, :]
+@test_throws DimensionMismatch @.. Ashim * y' + x # test fallback
+@test (@.. broadcast = true Ashim * y' + x) ≈ (@. Ashim * y' + x) # test fallback
+Av = view(A, 1, :)
+@test (@.. Av * y' + A) ≈ (@. Av * y' + A)
+B = similar(A)
+@.. B .= A
+@test B == A
+@.. A = 3
+@test all(==(3), A)
+@test (@.. 2 + 3 * 7 - cos(π)) === 24.0
+foo(f, x) = f(x)
+@test (@.. foo(abs2, x)) == abs2.(x)
+
+a = [1, 2]
+b = [3, 5]
+c = 1
+res = @.. @views a = c * b[1:2]
+@test res == (@. @views a = c * b[1:2])
+@test a === (@.. a)
+@test (a .^ b) == (@.. a^b)
+@static if VERSION >= v"1.6"
+    var".foo"(a) = a
+    @views @.. a = var".foo".(b[1:2]) .+ $abs2(c)
+    @views @.. thread = true a = var".foo".(b[1:2]) .+ $(abs2(c))
+    @test a == [4, 6]
+else
+    a = [4, 6]
+end
+@test (@.. x[2:3, 1] + a) == [6, 9]
+r = copy(y)
+@test (@.. r[3:4] += x[2:3, 1] + a) == [13, 17]
+@test (@views @.. r[3:4] += x[2:3, 1] + a) == [19, 26]
+@test (@.. @views r[3:4] += x[2:3, 1] + a) == [25, 35]
+@test r == [5, 6, 25, 35]
+@test (@.. r + r[end]) == [40, 41, 60, 70]
+
+# Issue #89: fancy indexing on LHS must write through (not silently copy).
+let temp = [0.0, 0.0], data = [1.0, 1.0]
+    @.. temp[[2]] = data[[2]]
+    @test temp == [0.0, 1.0]
+    @.. temp[[1]] = data[[1]]
+    @test temp == [1.0, 1.0]
+end
+
+let
+    @.. x = y
+    @test x == y
+    z = [y[1]]
+    @.. broadcast = true x = z
+    @test all(==(only(z)), x)
+end
+
+
+Q = rand(5, 2)
+k = 1
+v = 100 .* rand(5)
+d = 5
+@.. @view(Q[:, k]) = v / d
+@test Q ≈ hcat(v ./ d, @view(Q[:, 2]))
+@testset "Sparse" begin
+    x = sparse([1, 2, 0, 4])
+    y = sparse([1, 0, 0, 4])
+    res = @.. x + y
+    @test res isa SparseVector
+    @test res == (@. x + y)
+    res = @.. y = x + y
+    @test res isa SparseVector
+    @test res == [2, 2, 0, 8]
+    res = @.. x = x + y
+    @test res isa SparseVector
+    @test res == [3, 4, 0, 12]
+    z = sparse([1])
+    @.. broadcast = true x = z
+    @test all(isone, x)
+end
+let
+    N = 4
+    A = randn(N, N)
+    C = similar(A)
+    d = rand(N)
+    dt = transpose(d)  # could also use permutedims, same problem
+    @.. thread = true broadcast = false C = A * dt
+    @test C ≈ A .* dt
+    @test_throws DimensionMismatch @.. broadcast = false A * [1.0]
+end
+@test FastBroadcast.indices_do_not_alias(typeof(view(fill(0, 10), 1:4)))
+
+@testset "Runtime threading dispatch" begin
+    x2, y2 = [1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]
+    expected = @. x2 + y2
+    for threadopt in (false, true)
+        dst_rt = similar(x2)
+        @.. thread = threadopt dst_rt = x2 + y2
+        @test dst_rt == expected
+    end
+end
+
+let ex = macroexpand(
+        @__MODULE__,
+        :(@.. broadcast = false @view(J[idxs]) = @view(J[idxs]) - inv_alpha),
+    )
+    @test Base.Meta.isexpr(ex, :call)
+    @test ex.args[1] === FastBroadcast.fast_materialize!
+end
+let v = rand(8), A = rand(4, 2), V = rand(8, 1), a = similar(v), b = similar(v)
+    @test (@. a = V) == (@.. b = V)
+    @test (@. a += V) == (@.. b += V)
+    @test_throws DimensionMismatch @.. a = A
+    @test_throws DimensionMismatch @.. a += A
+end
+
+@testset "Polyester error hint (issue #91)" begin
+    # Run a fresh Julia process that loads FastBroadcast without Polyester,
+    # trigger `@.. thread=true`, and check that the MethodError shows a hint
+    # pointing the user to `using Polyester`.
+    script = """
+        push!(LOAD_PATH, $(repr(dirname(Base.active_project()))))
+        using FastBroadcast
+        @assert Base.get_extension(FastBroadcast, :FastBroadcastPolyesterExt) === nothing
+        xs = [1.0, 2.0, 3.0]
+        try
+            @.. thread=true sin(xs)
+            error("expected MethodError but call succeeded")
+        catch err
+            err isa MethodError || rethrow()
+            io = IOBuffer()
+            Base.showerror(io, err)
+            msg = String(take!(io))
+            occursin("using Polyester", msg) || error("hint missing:\\n" * msg)
+        end
+    """
+    cmd = `$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) -e $script`
+    @test success(pipeline(cmd; stdout = stdout, stderr = stderr))
+end

--- a/test/dimensionmismatch_tests.jl
+++ b/test/dimensionmismatch_tests.jl
@@ -1,0 +1,6 @@
+using FastBroadcast
+using Test
+
+A = rand(4, 2)
+v = rand(8)
+@test_throws Base.DimensionMismatch @.. A = v

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -3,6 +3,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [sources]
@@ -11,5 +12,6 @@ FastBroadcast = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+SafeTestsets = "0.1, 1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -2,10 +2,11 @@ using Pkg
 Pkg.activate(@__DIR__)
 Pkg.instantiate()
 
-using FastBroadcast
-using Aqua, JET, Test
+using SafeTestsets
 
-@testset "Aqua" begin
+@safetestset "Aqua" begin
+    using FastBroadcast
+    using Aqua, Test
     # deps_compat currently fails: no [compat] entry for the stdlib dep
     # LinearAlgebra (deps) nor for the test extra Pkg (extras).
     # Tracked in https://github.com/SciML/FastBroadcast.jl/issues/101
@@ -13,7 +14,9 @@ using Aqua, JET, Test
     @test_broken false  # Aqua deps_compat: missing [compat] for LinearAlgebra (deps) and Pkg (extras) — tracked in https://github.com/SciML/FastBroadcast.jl/issues/101
 end
 
-@testset "JET" begin
+@safetestset "JET" begin
+    using FastBroadcast
+    using JET, Test
     # JET.test_package reports the threaded fast_materialize paths (from the
     # FastBroadcastPolyesterExt extension) as missing methods because the
     # weakdep extension is not loaded during report_package.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using FastBroadcast
 using Polyester  # loads FastBroadcastPolyesterExt
 using SparseArrays
 using PerformanceTestTools, Test
+using SafeTestsets
 
 const GROUP = get(ENV, "GROUP", "All")
 
@@ -12,181 +13,12 @@ function activate_downstream_env()
 end
 
 if GROUP == "All" || GROUP == "Core"
-    @testset "FastBroadcast" begin
-        x, y = [1, 2, 3, 4], [5, 6, 7, 8]
-        dst = zeros(Int, 4)
-        bc = Broadcast.Broadcasted(+, (Broadcast.Broadcasted(*, (x, y)), x, y, x, y, x, y))
-        bcref = copy(bc)
-        @test FastBroadcast.fast_materialize_threaded!(
-            dst,
-            bc,
-        ) == bcref
-        @test FastBroadcast.fast_materialize!(
-            FastBroadcast.Serial(),
-            dst,
-            bc,
-        ) == bcref
-        dest = similar(bcref)
-        @test (@.. dest = (x * y) + x + y + x + y + x + y) == bcref
-        @test (@.. (x * y) + x + y + x + y + x + y) == bcref
-        @test (@.. thread = true dest .+= (x * y) + x + y + x + y + x + y) ≈ 2bcref
-        destwrap = [dest]
-        @test (@.. destwrap[end] .-= (x * y) + x + y + x + y + x + y) ≈ bcref
-        @test (@.. thread = true dest *= (x * y) + x + y + x + y + x + y) ≈ abs2.(bcref)
-
-        @test (@.. broadcast = false destwrap[end] = (x * y) + x + y + x + y + x + y) == bcref
-        @test (@.. broadcast = false (x * y) + x + y + x + y + x + y) == bcref
-        @test (@.. broadcast = false thread = true dest .+= (x * y) + x + y + x + y + x + y) ≈
-            2bcref
-        @test (@.. broadcast = false dest .-= (x * y) + x + y + x + y + x + y) ≈ bcref
-        @test (@.. broadcast = false thread = true dest *= (x * y) + x + y + x + y + x + y) ≈
-            abs2.(bcref)
-
-        nt = (x = x,)
-        @test (@.. (nt.x * y) + x + y + x * (3, 4, 5, 6) + y + x * (1,) + y + 3) ≈
-            (@. (x * y) + x + y + x * (3, 4, 5, 6) + y + nt.x * (1,) + y + 3)
-        A = rand(4, 4)
-        @test (@.. A * y' + x) ≈ (@. A * y' + x)
-        @test (@.. A * transpose(y) + x) ≈ (@. A * transpose(y) + x)
-        Ashim = A[1:1, :]
-        @test_throws DimensionMismatch @.. Ashim * y' + x # test fallback
-        @test (@.. broadcast = true Ashim * y' + x) ≈ (@. Ashim * y' + x) # test fallback
-        Av = view(A, 1, :)
-        @test (@.. Av * y' + A) ≈ (@. Av * y' + A)
-        B = similar(A)
-        @.. B .= A
-        @test B == A
-        @.. A = 3
-        @test all(==(3), A)
-        @test (@.. 2 + 3 * 7 - cos(π)) === 24.0
-        foo(f, x) = f(x)
-        @test (@.. foo(abs2, x)) == abs2.(x)
-
-        a = [1, 2]
-        b = [3, 5]
-        c = 1
-        res = @.. @views a = c * b[1:2]
-        @test res == (@. @views a = c * b[1:2])
-        @test a === (@.. a)
-        @test (a .^ b) == (@.. a^b)
-        @static if VERSION >= v"1.6"
-            var".foo"(a) = a
-            @views @.. a = var".foo".(b[1:2]) .+ $abs2(c)
-            @views @.. thread = true a = var".foo".(b[1:2]) .+ $(abs2(c))
-            @test a == [4, 6]
-        else
-            a = [4, 6]
-        end
-        @test (@.. x[2:3, 1] + a) == [6, 9]
-        r = copy(y)
-        @test (@.. r[3:4] += x[2:3, 1] + a) == [13, 17]
-        @test (@views @.. r[3:4] += x[2:3, 1] + a) == [19, 26]
-        @test (@.. @views r[3:4] += x[2:3, 1] + a) == [25, 35]
-        @test r == [5, 6, 25, 35]
-        @test (@.. r + r[end]) == [40, 41, 60, 70]
-
-        # Issue #89: fancy indexing on LHS must write through (not silently copy).
-        let temp = [0.0, 0.0], data = [1.0, 1.0]
-            @.. temp[[2]] = data[[2]]
-            @test temp == [0.0, 1.0]
-            @.. temp[[1]] = data[[1]]
-            @test temp == [1.0, 1.0]
-        end
-
-        let
-            @.. x = y
-            @test x == y
-            z = [y[1]]
-            @.. broadcast = true x = z
-            @test all(==(only(z)), x)
-        end
-
-
-        Q = rand(5, 2)
-        k = 1
-        v = 100 .* rand(5)
-        d = 5
-        @.. @view(Q[:, k]) = v / d
-        @test Q ≈ hcat(v ./ d, @view(Q[:, 2]))
-        @testset "Sparse" begin
-            x = sparse([1, 2, 0, 4])
-            y = sparse([1, 0, 0, 4])
-            res = @.. x + y
-            @test res isa SparseVector
-            @test res == (@. x + y)
-            res = @.. y = x + y
-            @test res isa SparseVector
-            @test res == [2, 2, 0, 8]
-            res = @.. x = x + y
-            @test res isa SparseVector
-            @test res == [3, 4, 0, 12]
-            z = sparse([1])
-            @.. broadcast = true x = z
-            @test all(isone, x)
-        end
-        let
-            N = 4
-            A = randn(N, N)
-            C = similar(A)
-            d = rand(N)
-            dt = transpose(d)  # could also use permutedims, same problem
-            @.. thread = true broadcast = false C = A * dt
-            @test C ≈ A .* dt
-            @test_throws DimensionMismatch @.. broadcast = false A * [1.0]
-        end
-        @test FastBroadcast.indices_do_not_alias(typeof(view(fill(0, 10), 1:4)))
-
-        @testset "Runtime threading dispatch" begin
-            x2, y2 = [1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]
-            expected = @. x2 + y2
-            for threadopt in (false, true)
-                dst_rt = similar(x2)
-                @.. thread = threadopt dst_rt = x2 + y2
-                @test dst_rt == expected
-            end
-        end
-
-        let ex = macroexpand(
-                @__MODULE__,
-                :(@.. broadcast = false @view(J[idxs]) = @view(J[idxs]) - inv_alpha),
-            )
-            @test Base.Meta.isexpr(ex, :call)
-            @test ex.args[1] === FastBroadcast.fast_materialize!
-        end
-        let v = rand(8), A = rand(4, 2), V = rand(8, 1), a = similar(v), b = similar(v)
-            @test (@. a = V) == (@.. b = V)
-            @test (@. a += V) == (@.. b += V)
-            @test_throws DimensionMismatch @.. a = A
-            @test_throws DimensionMismatch @.. a += A
-        end
-
-        @testset "Polyester error hint (issue #91)" begin
-            # Run a fresh Julia process that loads FastBroadcast without Polyester,
-            # trigger `@.. thread=true`, and check that the MethodError shows a hint
-            # pointing the user to `using Polyester`.
-            script = """
-                push!(LOAD_PATH, $(repr(dirname(Base.active_project()))))
-                using FastBroadcast
-                @assert Base.get_extension(FastBroadcast, :FastBroadcastPolyesterExt) === nothing
-                xs = [1.0, 2.0, 3.0]
-                try
-                    @.. thread=true sin(xs)
-                    error("expected MethodError but call succeeded")
-                catch err
-                    err isa MethodError || rethrow()
-                    io = IOBuffer()
-                    Base.showerror(io, err)
-                    msg = String(take!(io))
-                    occursin("using Polyester", msg) || error("hint missing:\\n" * msg)
-                end
-            """
-            cmd = `$(Base.julia_cmd()) --startup-file=no --project=$(Base.active_project()) -e $script`
-            @test success(pipeline(cmd; stdout = stdout, stderr = stderr))
-        end
+    @safetestset "FastBroadcast" begin
+        include("core_tests.jl")
     end
-    A = rand(4, 2)
-    v = rand(8)
-    @test_throws Base.DimensionMismatch @.. A = v
+    @safetestset "DimensionMismatch" begin
+        include("dimensionmismatch_tests.jl")
+    end
     VERSION >= v"1.6" && PerformanceTestTools.@include("vectorization_tests.jl")
 end
 


### PR DESCRIPTION
## What

Wrap each independent top-level test unit in `@safetestset` so it runs in its own module, matching the canonical OrdinaryDiffEq structure (isolation between units + world-age safety). No change to which tests run under which GROUP, no change to assertions, no change to the GROUP-dispatch structure.

## Changes

**Core group**
- The monolithic `@testset "FastBroadcast"` body and the trailing standalone `DimensionMismatch` test are each moved into a self-contained included file (`test/core_tests.jl`, `test/dimensionmismatch_tests.jl`) and wrapped as `@safetestset "..." begin include(...) end`.
- The `include` form (rather than an inline `@safetestset` body) is required here for two reasons:
  1. The suite uses `$` interpolation inside `@..` (e.g. `$abs2(c)`), which collides with SafeTestsets' `@eval module` interpolation — an inline body raises `UndefVarError: c not defined in SafeTestsets`.
  2. `@..` must be imported before it is parsed in the unit; with an inline body the `using FastBroadcast` and the macro use land in the same `@eval module` toplevel block, so `@..` is undefined at lowering. `include` evaluates statements sequentially, so the `using` runs first.
- Each included file carries its own `using` lines (`FastBroadcast`, `Polyester`, `SparseArrays`, `Test`).
- Nested grouping `@testset`s (`Sparse`, `Runtime threading dispatch`, `Polyester error hint`) stay plain — the unit-level `@safetestset` already isolates them.
- The `PerformanceTestTools.@include("vectorization_tests.jl")` already runs in its own subprocess; left unchanged.

**QA group**
- The plain `@testset "Aqua"` / `@testset "JET"` units become `@safetestset`, each with its own `using` lines. `Pkg.activate(@__DIR__)` stays at file top.

**Deps**
- Add `SafeTestsets` to the main `Project.toml` (`[extras]`, `[targets].test`, `[compat] = "0.1, 1"`) and to `test/qa/Project.toml`.

## Verification (local, julia 1.11)

- `GROUP=Core` -> `FastBroadcast` 56/56 pass, `DimensionMismatch` 1/1 pass, vectorization subprocess passed.
- `GROUP=QA` -> `Aqua` 7 pass / 1 broken, `JET` 1 broken (unchanged `@test_broken` structure).

Behavior-preserving: same tests, same assertions, same counts; only the unit isolation changed.

This is the test-isolation canonicalization only; the `run_tests` GROUP-dispatch harness migration is a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Ignore until reviewed by @ChrisRackauckas.