### PR TITLE
Document public API: add docstrings + docs entries

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,13 @@
+name: Documentation
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+    tags: "*"
+jobs:
+  build:
+    uses: "SciML/.github/.github/workflows/documentation.yml@v1"
+    secrets: "inherit"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.jl.cov
 *.jl.mem
 /Manifest.toml
+/docs/build/
+/docs/Manifest.toml

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
+
+[compat]
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,24 @@
+using Documenter, FastBroadcast
+
+makedocs(
+    sitename = "FastBroadcast.jl",
+    authors = "Yingbo Ma, Chris Elrod, and contributors",
+    modules = [FastBroadcast],
+    clean = true,
+    doctest = false,
+    linkcheck = false,
+    checkdocs = :exports,
+    format = Documenter.HTML(
+        assets = String[],
+        canonical = "https://docs.sciml.ai/FastBroadcast/stable/"
+    ),
+    pages = [
+        "Home" => "index.md",
+        "API" => "api.md",
+    ]
+)
+
+deploydocs(
+    repo = "github.com/SciML/FastBroadcast.jl.git";
+    push_preview = true
+)

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,17 @@
+# [API](@id API)
+
+The public interface of FastBroadcast.jl consists of the [`@..`](@ref) macro and
+the [`Serial`](@ref) and [`Threaded`](@ref) threading-dispatch types.
+
+## The `@..` macro
+
+```@docs
+@..
+```
+
+## Threading dispatch types
+
+```@docs
+Serial
+Threaded
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,41 @@
+# FastBroadcast.jl
+
+FastBroadcast.jl exports [`@..`](@ref) that compiles broadcast expressions into
+loops that are easier for the compiler to optimize.
+
+```julia
+using FastBroadcast
+
+function fast_foo9(a, b, c, d, e, f, g, h, i)
+    @.. a = b + 0.1 * (0.2c + 0.3d + 0.4e + 0.5f + 0.6g + 0.6h + 0.6i)
+    nothing
+end
+```
+
+It is important to note that FastBroadcast does not speed up "dynamic broadcast",
+i.e. when the arguments are not equal-axised or scalars. For example, dynamic
+broadcast happens when the expansion of singleton dimensions occurs.
+
+## Threading
+
+The macro [`@..`](@ref) accepts a keyword argument `thread` to control whether the
+broadcast should use multithreading via
+[Polyester.jl](https://github.com/JuliaSIMD/Polyester.jl) (disabled by default).
+Start Julia with multiple threads to benefit from this, and load `Polyester` to
+activate the threaded code path.
+
+```julia
+using FastBroadcast, Polyester
+
+function foo_parallel!(dest, src)
+    @.. thread = true dest = log(src)
+end
+```
+
+The `thread` argument accepts `true`/`false` or the exported types
+[`Serial`](@ref)`()`/[`Threaded`](@ref)`()`. When the threading choice is stored
+in a type-parameterized struct (e.g. an algorithm configuration), using
+`Serial()`/`Threaded()` enables compile-time dispatch and avoids invalidations
+when Polyester is loaded.
+
+See the [API](@ref) page for the full public interface.


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## What

FastBroadcast.jl exports three public names — `@..`, `Serial`, and `Threaded`. All three already carried docstrings on their source definitions, but the package shipped **no rendered documentation site at all**, so none of the public names appeared in any `@docs` block. Per the "everything public must be documented" rule, public names need BOTH a docstring AND a rendered-docs entry.

This PR adds a minimal Documenter site so every public name has a rendered docs entry:

- `docs/make.jl` — Documenter build. `checkdocs = :exports` makes the build **error** (not warn) if any exported public name lacks a rendered `@docs` entry, while not forcing the internal `fast_materialize_threaded[!]` docstrings into the manual.
- `docs/Project.toml` — docs environment (Documenter 1).
- `docs/src/index.md` — landing page (mirrors the README intro, cross-links the API page).
- `docs/src/api.md` — API reference with `@docs` blocks for `@..`, `Serial`, `Threaded`.
- `.github/workflows/Documentation.yml` — calls the SciML centralized `documentation.yml@v1` reusable workflow.
- `.gitignore` — ignore `docs/build/` and `docs/Manifest.toml`.

No `src/` changes: the docstrings were already present and correct; only the rendered-docs entries were missing.

## Validation

Built the docs locally with the actual `docs/make.jl` (Julia 1.12, released deps):

```
[ Info: CheckDocument: running document checks.
[ Info: Populate: populating indices.
[ Info: RenderDocument: rendering document.
```

- Build exits 0 with no `docstring not found` / `missing docs` Documenter errors and no `warnonly` (never set).
- Rendered `docs/build/api/index.html` contains docstring anchors `id="FastBroadcast.@.."`, `id="FastBroadcast.Serial"`, `id="FastBroadcast.Threaded"`.
- Confirmed each docstring attaches on the loaded package (`@doc FastBroadcast.<name>` non-empty for all three).

Runic-clean on `docs/make.jl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)