### PR TITLE
Bump version to 1.3.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FastBroadcast"
 uuid = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
-version = "1.3.3"
+version = "1.3.4"
 authors = ["Yingbo Ma <mayingbo5@gmail.com> and Chris Elrod <elrodc@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (1.3.3 -> 1.3.4) to release unreleased commits on `master` via JuliaRegistrator.