### PR TITLE
Target DiffEqBase in the OrdinaryDiffEq monorepo

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -12,11 +12,12 @@ jobs:
       matrix:
         julia-version: ['1']
         package:
-          - {user: SciML, repo: DiffEqBase.jl, group: All}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqBase, group: All}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       julia-version: "${{ matrix.julia-version }}"
       repo: "${{ matrix.package.repo }}"
       owner: "${{ matrix.package.user }}"
+      subdir: "${{ matrix.package.subdir }}"
       group: "${{ matrix.package.group }}"
     secrets: "inherit"

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         julia-version: ['1']
         package:
-          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqBase, group: All}
+          - {user: SciML, repo: OrdinaryDiffEq.jl, subdir: lib/DiffEqBase, group: ALL}
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       julia-version: "${{ matrix.julia-version }}"


### PR DESCRIPTION
## Summary

- replace the archived `SciML/DiffEqBase.jl` checkout with `SciML/OrdinaryDiffEq.jl`
- run the registered `lib/DiffEqBase` project through the reusable workflow
- preserve the existing `All` test selection

Depends on SciML/.github#115. Until that PR is merged and the `v1` tag is updated, GitHub will reject the new `subdir` caller input at workflow startup.

## Local verification

- `actionlint -color .github/workflows/Downstream.yml`
- `julia +1.12 -m Runic --check .`
- `git diff --check`
- exact reusable-workflow test path with this FastBroadcast checkout developed into `OrdinaryDiffEq.jl/lib/DiffEqBase`, `GROUP=All`: exit 0; substantive test summaries were emitted and the run ended with `Testing DiffEqBase tests passed`

Please ignore this PR until it is reviewed by @ChrisRackauckas.