### PR TITLE
Enable rendered docs QA for FastBroadcast

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -40,6 +40,12 @@ const EI_KWARGS = (;
         aqua_kwargs = (; deps_compat = false),
         explicit_imports = true,
         ei_kwargs = EI_KWARGS,
+        api_docs_kwargs = (;
+            rendered = true,
+            # `@..` is rendered in docs/src/api.md, but SciMLTesting parses it as
+            # Symbol("") because the macro name itself ends in dots.
+            rendered_ignore = (Symbol("@.."),),
+        ),
     )
     @test_broken false  # Aqua deps_compat: missing [compat] for LinearAlgebra (deps) and Pkg (extras) — tracked in https://github.com/SciML/FastBroadcast.jl/issues/101
 end


### PR DESCRIPTION
This PR enables the SciMLTesting rendered public API docs check for FastBroadcast. Public API audit reports `@..`, `Serial`, and `Threaded`; all have docstrings and docs entries.

`@..` is already rendered in `docs/src/api.md`, but SciMLTesting 2.2 currently parses that macro entry as `Symbol("")` because the macro name itself ends in dots, so this uses a narrow `rendered_ignore = (Symbol("@.."),)` for the rendered check only. The docstring check still covers `@..`.

Ignore this PR until reviewed by @ChrisRackauckas.

Validation run locally:
- `git diff --check`
- QA: `Aqua + ExplicitImports` 13 pass / 1 pre-existing broken; `JET` 1 pre-existing broken
- `Pkg.test()`: FastBroadcast 56/56 and DimensionMismatch 1/1 passed
- docs build via `include("docs/make.jl")`: exited 0
- Runic v1.7.0 over `src`, `test`, and `docs`: exited 0
