### PR TITLE
Bump FastBroadcast to v1.3.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FastBroadcast"
 uuid = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
-version = "1.3.4"
+version = "1.3.5"
 authors = ["Yingbo Ma <mayingbo5@gmail.com> and Chris Elrod <elrodc@gmail.com>"]
 
 [deps]


### PR DESCRIPTION
Bumps `FastBroadcast` **v1.3.4 → v1.3.5** (patch) so the accumulated unreleased `src/` changes on `master` can be registered.

**Rationale:** Migrate FastBroadcast QA to SciMLTesting 2.4 (#113) (docs/QA/compat/internal; no public API or behavior break)

Part of a sweep of SciML packages whose source changed since their last registered version without a version bump.

> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)